### PR TITLE
btsk-5 : qa서버 배포 스크립트 작성. 일단 ci 미구축

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,56 @@
+# Multi-stage build를 위한 Dockerfile
+FROM amazoncorretto:21-alpine-jdk AS builder
+
+# 작업 디렉토리 설정
+WORKDIR /app
+
+# Gradle 캐시를 위한 레이어 분리
+COPY gradle/ gradle/
+COPY gradlew .
+COPY build.gradle .
+COPY settings.gradle .
+RUN chmod +x gradlew
+
+# 의존성 다운로드 (소스코드 변경 없이 캐시 활용)
+RUN ./gradlew dependencies --no-daemon
+
+# 소스코드 복사
+COPY src/ src/
+
+# JAR 파일 빌드
+RUN ./gradlew bootJar --no-daemon
+
+# 런타임 이미지
+FROM amazoncorretto:21-alpine
+
+# 작업 디렉토리 설정
+WORKDIR /app
+
+# 타임존 설정
+ENV TZ=Asia/Seoul
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+# 헬스체크 의존 도구 설치
+RUN apk add --no-cache wget
+
+# 보안 사용자 생성
+RUN addgroup -S spring && adduser -S spring -G spring
+
+# JAR 파일 복사
+COPY --from=builder /app/build/libs/*.jar app.jar
+
+# 소유권 변경
+RUN chown spring:spring app.jar
+
+# 보안 사용자 전환
+USER spring
+
+# 헬스체크
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD wget --no-verbose --tries=1 --spider http://localhost:8080/actuator/health || exit 1
+
+# 포트 노출
+EXPOSE 8080
+
+# 실행 명령
+ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ description = 'pullit'
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 

--- a/deploy-qa.sh
+++ b/deploy-qa.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Pullit QA 서버 배포 스크립트
+# 사용법: ./deploy-qa.sh
+
+set -e
+
+# 색상 정의
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# 환경 변수 확인
+if [ -z "$DOCKER_REGISTRY" ]; then
+    echo -e "${RED}Error: DOCKER_REGISTRY 환경 변수가 설정되지 않았습니다.${NC}"
+    echo "사용법: export DOCKER_REGISTRY=your-registry.com/pullit"
+    exit 1
+fi
+
+if [ -z "$DB_PASSWORD" ] || [ -z "$DB_ROOT_PASSWORD" ]; then
+    echo -e "${RED}Error: DB_PASSWORD 또는 DB_ROOT_PASSWORD 환경 변수가 설정되지 않았습니다.${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}🚀 Pullit QA 서버 배포 시작${NC}"
+
+# 1. 이미지 빌드 및 푸시
+echo -e "${YELLOW}📦 Docker 이미지 빌드 중...${NC}"
+docker build -t ${DOCKER_REGISTRY}:latest .
+
+echo -e "${YELLOW}⬆️ Docker 레지스트리에 이미지 푸시 중...${NC}"
+docker push ${DOCKER_REGISTRY}:latest
+
+echo -e "${GREEN}✅ 이미지 빌드 및 푸시 완료${NC}"
+
+# 2. EC2에서 실행할 명령어 출력
+echo -e "${GREEN}📋 EC2에서 실행할 명령어:${NC}"
+echo "=========================================="
+echo "# 1. EC2에 접속 후 다음 명령어들을 실행하세요:"
+echo ""
+echo "# 환경 변수 설정"
+echo "export DOCKER_REGISTRY=${DOCKER_REGISTRY}"
+echo "export DB_PASSWORD=${DB_PASSWORD}"
+echo "export DB_ROOT_PASSWORD=${DB_ROOT_PASSWORD}"
+echo ""
+echo "# 2. Docker Compose 파일 다운로드 (또는 직접 생성)"
+echo "curl -O https://raw.githubusercontent.com/your-repo/pullit/main/docker-compose.qa.yml"
+echo ""
+echo "# 3. 컨테이너 실행"
+echo "docker-compose -f docker-compose.qa.yml up -d"
+echo ""
+echo "# 4. 로그 확인"
+echo "docker-compose -f docker-compose.qa.yml logs -f pullit-qa-app"
+echo ""
+echo "# 5. 상태 확인"
+echo "curl http://localhost:8080/actuator/health"
+echo "=========================================="
+
+echo -e "${GREEN}🎉 로컬 빌드 완료! 위 명령어들을 EC2에서 실행하세요.${NC}"

--- a/docker-compose.qa.yml
+++ b/docker-compose.qa.yml
@@ -1,0 +1,68 @@
+version: '3.8'
+
+services:
+  # QA용 Spring Boot 애플리케이션
+  pullit-qa-app:
+    image: ${DOCKER_REGISTRY}/pullit-qa:latest
+    container_name: pullit-qa-app
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    environment:
+      # 데이터베이스 연결 설정
+      - DB_URL=jdbc:mariadb://pullit-qa-db:3306/pullit_qa?createDatabaseIfNotExist=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+      - DB_USERNAME=pullit_qa
+      - DB_PASSWORD=${DB_PASSWORD}
+      # Spring 프로필
+      - SPRING_PROFILES_ACTIVE=qa
+      # JVM 옵션 (메모리 최적화)
+      - JAVA_OPTS=-Xmx512m -Xms256m
+    depends_on:
+      pullit-qa-db:
+        condition: service_healthy
+    networks:
+      - pullit-qa-network
+    healthcheck:
+      test: [ "CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/actuator/health" ]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 40s
+
+  # QA용 MariaDB 데이터베이스
+  pullit-qa-db:
+    image: mariadb:10.11
+    container_name: pullit-qa-db
+    restart: unless-stopped
+    environment:
+      - MARIADB_DATABASE=pullit_qa
+      - MARIADB_USER=pullit_qa
+      - MARIADB_PASSWORD=${DB_PASSWORD}
+      - MARIADB_ROOT_PASSWORD=${DB_ROOT_PASSWORD}
+      - MARIADB_CHARSET=utf8mb4
+      - MARIADB_COLLATION=utf8mb4_unicode_ci
+    ports:
+      - "3306:3306"
+    volumes:
+      - pullit_qa_data:/var/lib/mysql
+      - ./db/init:/docker-entrypoint-initdb.d
+    networks:
+      - pullit-qa-network
+    healthcheck:
+      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${DB_ROOT_PASSWORD}" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+      - --default-time-zone=+09:00
+
+volumes:
+  pullit_qa_data:
+    driver: local
+
+networks:
+  pullit-qa-network:
+    driver: bridge


### PR DESCRIPTION
### Checklist

아래 사항을 모두 확인하고 체크해주세요.

- [x] PR 제목을 `이슈번호: 작업내용(명확히)`로 작성해주세요.

## PR 설명

운영 환경에서는 이미지 빌드 없이 로컬에서 빌드한 이미지를
Docker Hub에 푸시하고 EC2에서는 pull만 하는 방식으로 배포

멀티스테이징 방식으로 도커에 캐시 효율적이게 함.

주요 변경 사항:
- CORS 설정: 운영(prod), QA 환경별 프론트엔드 도메인 허용
  - prod: https://www.pull.it.kr, https://pull.it.kr
  - qa: https://qa.pull.it.kr, http://local.pull.it.kr:3000
- Docker 배포 시스템 구축
  - Multi-stage Dockerfile: Java 21 + Amazon Corretto 최적화
  - docker-compose.qa.yml: QA 환경 컨테이너 구성
  - deploy-qa.sh: 로컬 빌드 자동화 스크립트
- CI/CD 준비: 로컬 빌드 → Docker Hub 푸시 → EC2 pull 방식

배포 방식:
- 로컬: ./gradlew bootJar → docker build → docker push
- EC2: docker pull → docker-compose up (빌드 불필요)
- 이점: EC2 리소스 절약, 배포 속도 향상, 보안성 강화


Release Notes:

- N/A _or_ Added/Fixed/Improved ...
