### PR TITLE
btsk-16: 카카오 OAuth 2.0 인증 연동 초기 구현

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -7,4 +7,4 @@ services:
       - 'MARIADB_ROOT_PASSWORD=verysecret'
       - 'MARIADB_USER=myuser'
     ports:
-      - '3306'
+      - "127.0.0.1:3306:3306"

--- a/src/main/java/kr/it/pullit/PullitApplication.java
+++ b/src/main/java/kr/it/pullit/PullitApplication.java
@@ -2,8 +2,10 @@ package kr.it.pullit;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class PullitApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/kr/it/pullit/boot/properties/AppProps.java
+++ b/src/main/java/kr/it/pullit/boot/properties/AppProps.java
@@ -1,3 +1,6 @@
 package kr.it.pullit.boot.properties;
 
-public class AppProps {}
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app")
+public record AppProps(String baseUrl) {}

--- a/src/main/java/kr/it/pullit/boot/properties/SecurityProps.java
+++ b/src/main/java/kr/it/pullit/boot/properties/SecurityProps.java
@@ -1,3 +1,0 @@
-package kr.it.pullit.boot.properties;
-
-public class SecurityProps {}

--- a/src/main/java/kr/it/pullit/modules/auth/client/KakaoOAuthClient.java
+++ b/src/main/java/kr/it/pullit/modules/auth/client/KakaoOAuthClient.java
@@ -1,3 +1,0 @@
-package kr.it.pullit.modules.auth.client;
-
-public class KakaoOAuthClient {}

--- a/src/main/java/kr/it/pullit/modules/auth/kakaoauth/client/KakaoOAuthClient.java
+++ b/src/main/java/kr/it/pullit/modules/auth/kakaoauth/client/KakaoOAuthClient.java
@@ -1,0 +1,25 @@
+package kr.it.pullit.modules.auth.kakaoauth.client;
+
+import java.time.Duration;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class KakaoOAuthClient {
+
+  private static final int CONNECTION_TIME_OUT_SECOND = 10; // TODO: 정확한 시간 정책.
+  private static final int READ_TIME_OUT_SECOND = 10;
+
+  @Bean(name = "kakaoRestClient")
+  public RestClient kakaoRestClient(RestTemplateBuilder builder) {
+    RestTemplate restTemplate =
+        builder
+            .connectTimeout(Duration.ofSeconds(CONNECTION_TIME_OUT_SECOND))
+            .readTimeout(Duration.ofSeconds(READ_TIME_OUT_SECOND))
+            .build();
+    return RestClient.create(restTemplate);
+  }
+}

--- a/src/main/java/kr/it/pullit/modules/auth/kakaoauth/config/KakaoProps.java
+++ b/src/main/java/kr/it/pullit/modules/auth/kakaoauth/config/KakaoProps.java
@@ -1,0 +1,13 @@
+package kr.it.pullit.modules.auth.kakaoauth.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "oauth.kakao")
+public record KakaoProps(
+    String clientId,
+    String clientSecret,
+    String redirectUri,
+    String kauthUrl,
+    String authorizePath,
+    String tokenPath,
+    String userInfoPath) {}

--- a/src/main/java/kr/it/pullit/modules/auth/kakaoauth/service/KakaoAuthService.java
+++ b/src/main/java/kr/it/pullit/modules/auth/kakaoauth/service/KakaoAuthService.java
@@ -1,0 +1,16 @@
+package kr.it.pullit.modules.auth.kakaoauth.service;
+
+import kr.it.pullit.modules.auth.kakaoauth.util.KakaoUrlBuilder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoAuthService {
+
+  private final KakaoUrlBuilder kakaoUrlBuilder;
+
+  public String buildAuthorizeUrl(String state) {
+    return kakaoUrlBuilder.buildAuthorizeUrl(state);
+  }
+}

--- a/src/main/java/kr/it/pullit/modules/auth/kakaoauth/util/KakaoUrlBuilder.java
+++ b/src/main/java/kr/it/pullit/modules/auth/kakaoauth/util/KakaoUrlBuilder.java
@@ -1,0 +1,37 @@
+package kr.it.pullit.modules.auth.kakaoauth.util;
+
+import kr.it.pullit.modules.auth.kakaoauth.config.KakaoProps;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoUrlBuilder {
+
+  private final KakaoProps kakaoProps;
+
+  public String buildAuthorizeUrl(String state) {
+    String clientId = kakaoProps.clientId();
+    String redirectUri = kakaoProps.redirectUri();
+
+    if (clientId == null || clientId.isBlank()) {
+      throw new IllegalStateException("kakao.clientId 설정이 필요합니다.");
+    }
+    if (redirectUri == null || redirectUri.isBlank()) {
+      throw new IllegalStateException("kakao.redirectUri 설정이 필요합니다.");
+    }
+
+    UriComponentsBuilder builder =
+        UriComponentsBuilder.fromUriString(kakaoProps.kauthUrl() + kakaoProps.authorizePath())
+            .queryParam("client_id", clientId)
+            .queryParam("redirect_uri", redirectUri)
+            .queryParam("response_type", "code");
+
+    if (state != null && !state.isBlank()) {
+      builder.queryParam("state", state);
+    }
+
+    return builder.toUriString();
+  }
+}

--- a/src/main/java/kr/it/pullit/modules/auth/kakaoauth/web/KakaoAuthController.java
+++ b/src/main/java/kr/it/pullit/modules/auth/kakaoauth/web/KakaoAuthController.java
@@ -1,0 +1,27 @@
+package kr.it.pullit.modules.auth.kakaoauth.web;
+
+import java.net.URI;
+import kr.it.pullit.modules.auth.kakaoauth.service.KakaoAuthService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class KakaoAuthController {
+
+  private final KakaoAuthService kakaoAuthService;
+
+  public KakaoAuthController(KakaoAuthService kakaoAuthService) {
+    this.kakaoAuthService = kakaoAuthService;
+  }
+
+  @GetMapping("/oauth/authorize/kakao")
+  public ResponseEntity<Void> authorize(
+      @RequestParam(name = "state", required = false) String state) {
+    return ResponseEntity.status(HttpStatus.FOUND)
+        .location(URI.create(kakaoAuthService.buildAuthorizeUrl(state)))
+        .build();
+  }
+}

--- a/src/main/java/kr/it/pullit/modules/auth/service/KakaoAuthService.java
+++ b/src/main/java/kr/it/pullit/modules/auth/service/KakaoAuthService.java
@@ -1,3 +1,0 @@
-package kr.it.pullit.modules.auth.service;
-
-public class KakaoAuthService {}

--- a/src/main/java/kr/it/pullit/modules/auth/web/KakaoAuthController.java
+++ b/src/main/java/kr/it/pullit/modules/auth/web/KakaoAuthController.java
@@ -1,3 +1,0 @@
-package kr.it.pullit.modules.auth.web;
-
-public class KakaoAuthController {}

--- a/src/main/java/kr/it/pullit/platform/security/config/SecurityConfig.java
+++ b/src/main/java/kr/it/pullit/platform/security/config/SecurityConfig.java
@@ -21,7 +21,12 @@ public class SecurityConfig {
             authorize ->
                 authorize
                     .requestMatchers(
-                        "/", "/api", "/api/health", "/oauth/callback/**", "/login/oauth2/code/**")
+                        "/",
+                        "/api",
+                        "/api/health",
+                        "/oauth/callback/**",
+                        "/login/oauth2/code/**",
+                        "/oauth/authorize/**")
                     .permitAll()
                     .requestMatchers("/auth/me", "/auth/access-token/refresh", "/auth/logout")
                     .authenticated()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,13 +4,13 @@ spring:
 
   datasource:
     driver-class-name: org.mariadb.jdbc.Driver
-    url: ${DB_URL:jdbc:mariadb://localhost:3306/pullit_local?createDatabaseIfNotExist=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8}
-    username: ${DB_USERNAME:root}
-    password: ${DB_PASSWORD:root}
+    url: jdbc:mariadb://localhost:3306/mydatabase?createDatabaseIfNotExist=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: myuser
+    password: secret
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop
 
   liquibase:
     enabled: false
@@ -72,3 +72,16 @@ cors:
     - ${ACCESS_CONTROL_ALLOWED_ORIGINS:http://localhost:3000}
   # CORS 캐시 시간 (초 단위) - 개발: 5분, 운영: 1시간
   max-age-seconds: ${CORS_MAX_AGE_SECONDS:3600}
+
+oauth:
+  kakao:
+    client-id: ${KAKAO_CLIENT_ID:}
+    client-secret: ${KAKAO_CLIENT_SECRET:}
+    redirect-uri: ${KAKAO_REDIRECT_URI:}
+    kauth-url: https://kauth.kakao.com
+    authorize-path: /oauth/authorize
+    token-path: /oauth/token
+    user-info-path: /v2/user/me
+
+app:
+  base-url: ${BASE_URL:}


### PR DESCRIPTION

## PR 설명

Feat: 카카오 OAuth 2.0 인증 연동 초기 구현

- KakaoProps 추가: 카카오 OAuth 설정(clientId, secret, redirectUri 등) 관리.
- KakaoUrlBuilder 추가: 카카오 인증 URL 생성 기능 구현.
- KakaoAuthController 추가: 인증 요청 처리 엔드포인트(/oauth/authorize/kakao) 제공.
- KakaoAuthService 추가: 인증 URL 빌드 로직 분리.
- kakaoRestClient 등록: 카카오 API 호출을 위한 RestClient 설정.
- AppProps 및 application.yml 수정: app.base-url 설정 추가.
  앱의 base-url 설정을 위함.

- DB 설정 변경: datasource URL과 사용자 정보 수정, Hibernate 개발 편의성을 위해 ddl-auto create-drop으로 설정.

Release Notes:

- N/A _or_ Added/Fixed/Improved ...
