### PR TITLE
btsk-41: 기본 폴더 조회/생성 로직  및 Source API 개선

### DIFF
--- a/src/main/java/kr/it/pullit/modules/learningsource/source/domain/entity/Source.java
+++ b/src/main/java/kr/it/pullit/modules/learningsource/source/domain/entity/Source.java
@@ -55,6 +55,8 @@ public class Source extends BaseEntity {
   @Column(nullable = false)
   private Long fileSizeBytes;
 
+  private Integer pageCount;
+
   @Enumerated(EnumType.STRING)
   @Column(nullable = false)
   private SourceStatus status;

--- a/src/main/java/kr/it/pullit/modules/learningsource/source/repository/SourceRepository.java
+++ b/src/main/java/kr/it/pullit/modules/learningsource/source/repository/SourceRepository.java
@@ -8,11 +8,13 @@ public interface SourceRepository {
 
   Source save(Source source);
 
+  Optional<Source> findById(Long id);
+
   List<Source> findByMemberIdOrderByCreatedAtDesc(Long memberId);
+
+  List<Source> findSourcesByMemberIdWithDetails(Long memberId);
 
   List<Source> findByIdIn(List<Long> ids);
 
   Optional<Source> findByIdAndMemberId(Long id, Long memberId);
-
-  Optional<Source> findById(Long id);
 }

--- a/src/main/java/kr/it/pullit/modules/learningsource/source/repository/SourceRepositoryImpl.java
+++ b/src/main/java/kr/it/pullit/modules/learningsource/source/repository/SourceRepositoryImpl.java
@@ -18,15 +18,19 @@ public class SourceRepositoryImpl implements SourceRepository {
     return sourceJpaRepository.save(source);
   }
 
-  /**
-   * 사용처: 학습 소스 목록 조회 API.
-   *
-   * @param memberId 조회 대상 회원 식별자
-   * @return 생성일시 최신순의 소스 목록
-   */
+  @Override
+  public Optional<Source> findById(Long id) {
+    return sourceJpaRepository.findById(id);
+  }
+
   @Override
   public List<Source> findByMemberIdOrderByCreatedAtDesc(Long memberId) {
     return sourceJpaRepository.findByMemberIdOrderByCreatedAtDesc(memberId);
+  }
+
+  @Override
+  public List<Source> findSourcesByMemberIdWithDetails(Long memberId) {
+    return sourceJpaRepository.findSourcesByMemberIdWithDetails(memberId);
   }
 
   @Override
@@ -37,10 +41,5 @@ public class SourceRepositoryImpl implements SourceRepository {
   @Override
   public Optional<Source> findByIdAndMemberId(Long id, Long memberId) {
     return sourceJpaRepository.findByIdAndMemberId(id, memberId);
-  }
-
-  @Override
-  public Optional<Source> findById(Long id) {
-    return sourceJpaRepository.findById(id);
   }
 }

--- a/src/main/java/kr/it/pullit/modules/learningsource/source/repository/adapter/jpa/SourceJpaRepository.java
+++ b/src/main/java/kr/it/pullit/modules/learningsource/source/repository/adapter/jpa/SourceJpaRepository.java
@@ -4,10 +4,20 @@ import java.util.List;
 import java.util.Optional;
 import kr.it.pullit.modules.learningsource.source.domain.entity.Source;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SourceJpaRepository extends JpaRepository<Source, Long> {
 
   List<Source> findByMemberIdOrderByCreatedAtDesc(Long memberId);
+
+  @Query(
+      "SELECT DISTINCT s FROM Source s "
+          + "LEFT JOIN FETCH s.sourceFolder "
+          + "LEFT JOIN FETCH s.questionSets "
+          + "WHERE s.member.id = :memberId "
+          + "ORDER BY s.createdAt DESC")
+  List<Source> findSourcesByMemberIdWithDetails(@Param("memberId") Long memberId);
 
   Optional<Source> findByIdAndMemberId(Long id, Long memberId);
 

--- a/src/main/java/kr/it/pullit/modules/learningsource/source/web/dto/SourceResponse.java
+++ b/src/main/java/kr/it/pullit/modules/learningsource/source/web/dto/SourceResponse.java
@@ -1,30 +1,52 @@
 package kr.it.pullit.modules.learningsource.source.web.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 import kr.it.pullit.modules.learningsource.source.constant.SourceStatus;
 import kr.it.pullit.modules.learningsource.source.domain.entity.Source;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
+import kr.it.pullit.modules.questionset.domain.entity.QuestionSet;
 
-@Data
-@Builder
-@AllArgsConstructor
-public class SourceResponse {
-
-  private Long id;
-  private String originalName;
-  private SourceStatus status;
-  private Long fileSizeBytes;
-  private LocalDateTime createdAt;
-
+/**
+ * 내 학습 소스 조회 응답 DTO
+ *
+ * @param id 소스 ID
+ * @param originalName 소스 명 (원본 파일명)
+ * @param sourceFolderName 소스가 포함된 폴더 명
+ * @param status 학습 소스 상태
+ * @param questionSetCount 해당 소스로 만들어진 문제집 개수
+ * @param pageCount PDF 등 문서의 페이지 수
+ * @param fileSizeBytes 파일 크기 (byte 단위)
+ * @param createdAt 소스 업로드 날짜
+ * @param recentQuestionGeneratedAt 해당 소스로 문제집을 생성한 가장 최근 날짜
+ */
+public record SourceResponse(
+    Long id,
+    String originalName,
+    String sourceFolderName,
+    SourceStatus status,
+    Integer questionSetCount,
+    Integer pageCount,
+    Long fileSizeBytes,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+        LocalDateTime createdAt,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+        LocalDateTime recentQuestionGeneratedAt) {
   public static SourceResponse from(Source source) {
-    return SourceResponse.builder()
-        .id(source.getId())
-        .originalName(source.getOriginalName())
-        .status(source.getStatus())
-        .fileSizeBytes(source.getFileSizeBytes())
-        .createdAt(source.getCreatedAt())
-        .build();
+    LocalDateTime recentQuestionGeneratedAt =
+        source.getQuestionSets().stream()
+            .map(QuestionSet::getCreatedAt)
+            .max(LocalDateTime::compareTo)
+            .orElse(null);
+
+    return new SourceResponse(
+        source.getId(),
+        source.getOriginalName(),
+        source.getSourceFolder() != null ? source.getSourceFolder().getName() : null,
+        source.getStatus(),
+        source.getQuestionSets().size(),
+        source.getPageCount(),
+        source.getFileSizeBytes(),
+        source.getCreatedAt(),
+        recentQuestionGeneratedAt);
   }
 }

--- a/src/main/java/kr/it/pullit/modules/learningsource/sourcefolder/api/SourceFolderPublicApi.java
+++ b/src/main/java/kr/it/pullit/modules/learningsource/sourcefolder/api/SourceFolderPublicApi.java
@@ -10,4 +10,6 @@ public interface SourceFolderPublicApi {
   SourceFolder create(SourceFolder sourceFolder);
 
   Optional<SourceFolder> findDefaultFolderByMemberId(Long memberId);
+
+  SourceFolder findOrCreateDefaultFolder(Long memberId);
 }

--- a/src/main/java/kr/it/pullit/modules/learningsource/sourcefolder/repository/SourceFolderRepository.java
+++ b/src/main/java/kr/it/pullit/modules/learningsource/sourcefolder/repository/SourceFolderRepository.java
@@ -2,6 +2,7 @@ package kr.it.pullit.modules.learningsource.sourcefolder.repository;
 
 import java.util.Optional;
 import kr.it.pullit.modules.learningsource.sourcefolder.domain.entity.SourceFolder;
+import kr.it.pullit.modules.member.domain.entity.Member;
 
 public interface SourceFolderRepository {
 
@@ -10,4 +11,6 @@ public interface SourceFolderRepository {
   Optional<SourceFolder> findById(Long id);
 
   Optional<SourceFolder> findDefaultFolderByMemberId(Long memberId);
+
+  SourceFolder createDefaultFolder(Member member);
 }

--- a/src/main/java/kr/it/pullit/modules/learningsource/sourcefolder/repository/SourceFolderRepositoryImpl.java
+++ b/src/main/java/kr/it/pullit/modules/learningsource/sourcefolder/repository/SourceFolderRepositoryImpl.java
@@ -1,10 +1,8 @@
 package kr.it.pullit.modules.learningsource.sourcefolder.repository;
 
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import kr.it.pullit.modules.learningsource.sourcefolder.domain.entity.SourceFolder;
 import kr.it.pullit.modules.learningsource.sourcefolder.repository.adapter.jpa.SourceFolderJpaRepository;
-import kr.it.pullit.modules.member.api.MemberPublicApi;
 import kr.it.pullit.modules.member.domain.entity.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -14,7 +12,6 @@ import org.springframework.stereotype.Repository;
 public class SourceFolderRepositoryImpl implements SourceFolderRepository {
 
   private final SourceFolderJpaRepository sourceFolderJpaRepository;
-  private final MemberPublicApi memberPublicApi;
   private static final String DEFAULT_FOLDER_NAME = "전체 폴더";
 
   @Override
@@ -29,18 +26,11 @@ public class SourceFolderRepositoryImpl implements SourceFolderRepository {
 
   @Override
   public Optional<SourceFolder> findDefaultFolderByMemberId(Long memberId) {
-    return Optional.ofNullable(
-        sourceFolderJpaRepository
-            .findByMemberIdAndName(memberId, DEFAULT_FOLDER_NAME)
-            .orElseGet(() -> createDefaultFolder(memberId)));
+    return sourceFolderJpaRepository.findByMemberIdAndName(memberId, DEFAULT_FOLDER_NAME);
   }
 
-  private SourceFolder createDefaultFolder(Long memberId) {
-    Member member =
-        memberPublicApi
-            .findById(memberId)
-            .orElseThrow(() -> new NoSuchElementException("Member not found with id: " + memberId));
-
+  @Override
+  public SourceFolder createDefaultFolder(Member member) {
     SourceFolder defaultFolder =
         SourceFolder.builder()
             .member(member)

--- a/src/main/java/kr/it/pullit/modules/learningsource/sourcefolder/service/SourceFolderService.java
+++ b/src/main/java/kr/it/pullit/modules/learningsource/sourcefolder/service/SourceFolderService.java
@@ -1,9 +1,12 @@
 package kr.it.pullit.modules.learningsource.sourcefolder.service;
 
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import kr.it.pullit.modules.learningsource.sourcefolder.api.SourceFolderPublicApi;
 import kr.it.pullit.modules.learningsource.sourcefolder.domain.entity.SourceFolder;
 import kr.it.pullit.modules.learningsource.sourcefolder.repository.SourceFolderRepository;
+import kr.it.pullit.modules.member.api.MemberPublicApi;
+import kr.it.pullit.modules.member.domain.entity.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -12,6 +15,7 @@ import org.springframework.stereotype.Service;
 public class SourceFolderService implements SourceFolderPublicApi {
 
   private final SourceFolderRepository sourceFolderRepository;
+  private final MemberPublicApi memberPublicApi;
 
   @Override
   public Optional<SourceFolder> findById(Long id) {
@@ -26,5 +30,20 @@ public class SourceFolderService implements SourceFolderPublicApi {
   @Override
   public Optional<SourceFolder> findDefaultFolderByMemberId(Long memberId) {
     return sourceFolderRepository.findDefaultFolderByMemberId(memberId);
+  }
+
+  @Override
+  public SourceFolder findOrCreateDefaultFolder(Long memberId) {
+    return findDefaultFolderByMemberId(memberId)
+        .orElseGet(
+            () -> {
+              Member member =
+                  memberPublicApi
+                      .findById(memberId)
+                      .orElseThrow(
+                          () ->
+                              new NoSuchElementException("Member not found with id: " + memberId));
+              return sourceFolderRepository.createDefaultFolder(member);
+            });
   }
 }

--- a/src/main/resources/static/openapi/swagger.yml
+++ b/src/main/resources/static/openapi/swagger.yml
@@ -113,6 +113,10 @@ paths:
   /api/learning/source:
     get:
       summary: 내 학습 소스 조회
+      description: |
+        현재 로그인한 사용자가 업로드한 모든 학습 소스의 상세 목록을 조회합니다.
+        각 소스에 연결된 폴더 정보, 해당 소스로 생성된 문제집의 개수, 문서의 페이지 수 등
+        학습 소스 관리에 필요한 모든 메타데이터를 포함하여 반환합니다.
       operationId: getMySources
       tags:
         - learning-source
@@ -204,19 +208,40 @@ components:
           example: 1
         originalName:
           type: string
-          example: "document.pdf"
-        status:
+          description: "소스 명 (원본 파일명)"
+          example: "토익 RC 실전 문제집.pdf"
+        sourceFolderName:
           type: string
-          enum: [ UPLOADED, EXTRACTING, READY, FAILED ]
-          example: READY
+          nullable: true
+          description: "소스가 포함된 폴더의 이름"
+          example: "영어"
+        status:
+          $ref: '#/components/schemas/SourceStatus'
+        questionSetCount:
+          type: integer
+          description: "이 소스로 만들어진 문제집의 총 개수"
+          example: 2
+        pageCount:
+          type: integer
+          nullable: true
+          description: "PDF 파일의 전체 페이지 수"
+          example: 120
         fileSizeBytes:
           type: integer
           format: int64
-          example: 1048576
+          description: "파일 크기 (byte 단위)"
+          example: 3355443
         createdAt:
           type: string
-          format: date-time
-          example: "2023-10-27T10:00:00Z"
+          format: date
+          description: "소스 업로드 날짜"
+          example: "2024-01-20"
+        recentQuestionGeneratedAt:
+          type: string
+          format: date
+          nullable: true
+          description: "가장 최근에 문제집을 생성한 날짜"
+          example: "2024-03-15"
 
     SourceStatus:
       type: string


### PR DESCRIPTION
## PR 설명

레포지토리에서 member를 사용하던 기존 방식에서
좀 더 도메인간 결합성을 줄이는 방식으로, 즉 서비스단에서 비지니스 로직을 처리하는 방식으로 변경
- findOrCreateDefaultFolder 메서드
- SourceResponse 개선: QuestionSet 수, 페이지 수(pageCount) 등 상세 메타데이터 추가.
- findSourcesByMemberIdWithDetails 쿼리 및 메서드 추가: 소스 상세 정보와 관련 엔티티를 함께 조회.
- Source 엔티티에 pageCount 필드 및 업데이트 메서드 추가.
- Source API 트랜잭션 처리 도입

<!--Release Notes:

- N/A _or_ Added/Fixed/Improved ...-->
