### PR TITLE
btsk-39: 문제집 생성 API 호출 시에 실제 MemberId 호출 

### DIFF
--- a/src/main/java/kr/it/pullit/modules/questionset/web/QuestionSetController.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/web/QuestionSetController.java
@@ -26,6 +26,7 @@ public class QuestionSetController {
     private final MemberPublicApi memberPublicApi;
 
     @GetMapping("/{id}")
+    public ResponseEntity<QuestionSetDto> getQuestionSetById(@PathVariable Long id) {
         QuestionSetDto questionSetDto = questionSetPublicApi.getQuestionSetById(id);
         return ResponseEntity.ok(questionSetDto);
     }


### PR DESCRIPTION
## PR 설명
로그인 구현 후에 문제집 생성 컨트롤러에서 실제 memberId가 호출 되도록 수정하였습니다. 

<!-- 어떤 PR인지 자세히 설명해주세요 -->

<!--Release Notes:

- N/A _or_ Added/Fixed/Improved ...-->
