### PR TITLE
btsk-102: sse 중복 전송 해결

### DIFF
--- a/src/main/java/kr/it/pullit/modules/notification/api/NotificationEventPublicApi.java
+++ b/src/main/java/kr/it/pullit/modules/notification/api/NotificationEventPublicApi.java
@@ -5,7 +5,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 public interface NotificationEventPublicApi {
 
-  SseEmitter subscribe(Long userId, String lastEventId);
+  SseEmitter subscribe(Long userId, Long lastEventId);
 
   void publishQuestionSetCreationComplete(Long userId, QuestionSetCreationCompleteResponse data);
 }

--- a/src/main/java/kr/it/pullit/modules/notification/domain/EventData.java
+++ b/src/main/java/kr/it/pullit/modules/notification/domain/EventData.java
@@ -4,19 +4,23 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter.SseEventBuilder;
 
-public record EventData(long id, Long userId, String name, Object data) {
+public record EventData(Long id, Long userId, String name, Object data) {
 
-  private static final AtomicLong eventIdGenerator = new AtomicLong(System.currentTimeMillis());
+  private static final AtomicLong eventIdGenerator = new AtomicLong(0);
 
   public static EventData of(Long userId, String name, Object data) {
-    return new EventData(0, userId, name, data);
+    return new EventData(eventIdGenerator.getAndIncrement(), userId, name, data);
+  }
+
+  public static EventData heartbeat(Long userId) {
+    return new EventData(null, userId, "heartbeat" + System.currentTimeMillis(), "ping");
   }
 
   public SseEventBuilder toSseEventBuilder() {
-    return SseEmitter.event().id(String.valueOf(id)).name(name).data(data);
-  }
+    if (id == null) {
+      return SseEmitter.event().name(name).data(data);
+    }
 
-  public EventData withId(long id) {
-    return new EventData(id, this.userId, this.name, this.data);
+    return SseEmitter.event().id(String.valueOf(id)).name(name).data(data);
   }
 }

--- a/src/main/java/kr/it/pullit/modules/notification/domain/EventData.java
+++ b/src/main/java/kr/it/pullit/modules/notification/domain/EventData.java
@@ -12,6 +12,10 @@ public record EventData(Long id, Long userId, String name, Object data) {
     return new EventData(eventIdGenerator.getAndIncrement(), userId, name, data);
   }
 
+  public static EventData reConnection(Long userId, Long lastEventId) {
+    return new EventData(lastEventId, userId, "reconnection", "connection established");
+  }
+
   public static EventData heartbeat(Long userId) {
     return new EventData(null, userId, "heartbeat" + System.currentTimeMillis(), "ping");
   }

--- a/src/main/java/kr/it/pullit/modules/notification/repository/InMemorySseEventCache.java
+++ b/src/main/java/kr/it/pullit/modules/notification/repository/InMemorySseEventCache.java
@@ -1,10 +1,12 @@
 package kr.it.pullit.modules.notification.repository;
 
-import java.util.Deque;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Collectors;
 import kr.it.pullit.modules.notification.config.NotificationProperties;
 import kr.it.pullit.modules.notification.domain.EventData;
 import lombok.extern.slf4j.Slf4j;
@@ -15,7 +17,7 @@ import org.springframework.stereotype.Repository;
 public class InMemorySseEventCache implements SseEventCache {
 
   private final int cacheSize;
-  private final Deque<EventData> cache = new ConcurrentLinkedDeque<>();
+  private final Map<Long, Queue<EventData>> cache = new ConcurrentHashMap<>();
   private final AtomicLong idCounter = new AtomicLong(0);
 
   public InMemorySseEventCache(NotificationProperties notificationProperties) {
@@ -23,29 +25,46 @@ public class InMemorySseEventCache implements SseEventCache {
   }
 
   @Override
-  public EventData put(EventData event) {
-    long id = idCounter.incrementAndGet();
-    EventData newEventData = event.withId(id);
+  public void put(EventData event) {
+    cache.putIfAbsent(event.userId(), new ConcurrentLinkedDeque<>());
 
-    cache.add(newEventData);
-    if (cache.size() > cacheSize) {
-      cache.pollFirst();
+    Queue<EventData> userCache = cache.get(event.userId());
+    userCache.add(event);
+
+    if (userCache.size() > cacheSize) {
+      userCache.poll();
     }
-    log.debug("Event cached: {}", newEventData);
-    return newEventData;
+
+    log.debug("Event cached: {}", event);
   }
 
-  @Override
-  public List<EventData> findAllByUserIdAfter(Long userId, long lastEventId) {
-    return cache.stream()
-        .filter(
-            event ->
-                event.userId() != null && event.userId().equals(userId) && event.id() > lastEventId)
-        .collect(Collectors.toList());
-  }
+  public List<EventData> pollAllByUserIdAfter(Long userId, long lastEventId) {
+    List<EventData> result = new ArrayList<>();
 
-  public void clearByUserId(Long userId) {
-    cache.removeIf(event -> event.userId() != null && event.userId().equals(userId));
+    Queue<EventData> userCache = cache.getOrDefault(userId, null);
+    if (userCache == null) {
+      return result;
+    }
+
+    if (userCache.isEmpty()) {
+      return result;
+    }
+
+    int initialSize = userCache.size();
+
+    while (initialSize-- > 0) {
+      EventData event = userCache.poll();
+      if (event == null) {
+        break;
+      }
+
+      if (event.id() > lastEventId) {
+        result.add(event);
+        userCache.add(event);
+      }
+    }
+
+    return result;
   }
 
   @Override

--- a/src/main/java/kr/it/pullit/modules/notification/repository/InMemorySseEventCache.java
+++ b/src/main/java/kr/it/pullit/modules/notification/repository/InMemorySseEventCache.java
@@ -44,6 +44,10 @@ public class InMemorySseEventCache implements SseEventCache {
         .collect(Collectors.toList());
   }
 
+  public void clearByUserId(Long userId) {
+    cache.removeIf(event -> event.userId() != null && event.userId().equals(userId));
+  }
+
   @Override
   public void clear() {
     cache.clear();

--- a/src/main/java/kr/it/pullit/modules/notification/repository/SseEventCache.java
+++ b/src/main/java/kr/it/pullit/modules/notification/repository/SseEventCache.java
@@ -9,6 +9,8 @@ public interface SseEventCache {
 
   void clear();
 
+  void clearByUserId(Long userId);
+
   /**
    * 이 사용자를 위해 저장된 이벤트들 중에서, 클라이언트가 마지막으로 받았던 이벤트 ID보다 더 최신인 것들을 모두 찾아서 목록으로 반환한다. 재연결한 클라이언트에게, 연결이
    * 끊어져 있는 동안 놓쳤던 이벤트들만 정확히 골라서 다시 보내주기 위한 메서드

--- a/src/main/java/kr/it/pullit/modules/notification/repository/SseEventCache.java
+++ b/src/main/java/kr/it/pullit/modules/notification/repository/SseEventCache.java
@@ -5,11 +5,9 @@ import kr.it.pullit.modules.notification.domain.EventData;
 
 public interface SseEventCache {
 
-  EventData put(EventData event);
+  void put(EventData event);
 
   void clear();
-
-  void clearByUserId(Long userId);
 
   /**
    * 이 사용자를 위해 저장된 이벤트들 중에서, 클라이언트가 마지막으로 받았던 이벤트 ID보다 더 최신인 것들을 모두 찾아서 목록으로 반환한다. 재연결한 클라이언트에게, 연결이
@@ -19,5 +17,5 @@ public interface SseEventCache {
    * @param lastEventId 클라이언트가 마지막으로 받은 이벤트 ID
    * @return 유실된 이벤트들의 목록
    */
-  List<EventData> findAllByUserIdAfter(Long userId, long lastEventId);
+  List<EventData> pollAllByUserIdAfter(Long userId, long lastEventId);
 }

--- a/src/main/java/kr/it/pullit/modules/notification/service/NotificationEventService.java
+++ b/src/main/java/kr/it/pullit/modules/notification/service/NotificationEventService.java
@@ -27,7 +27,7 @@ public class NotificationEventService implements NotificationEventPublicApi {
   private final NotificationChannelFactory notificationChannelFactory;
 
   @Override
-  public SseEmitter subscribe(Long userId, String lastEventId) {
+  public SseEmitter subscribe(Long userId, Long lastEventId) {
     NotificationChannel channel = createAndRegisterChannel(userId);
     handleInitialConnection(channel, lastEventId);
     return channel.emitter();
@@ -62,13 +62,14 @@ public class NotificationEventService implements NotificationEventPublicApi {
     return channel;
   }
 
-  private void handleInitialConnection(NotificationChannel channel, String lastEventId) {
+  private void handleInitialConnection(NotificationChannel channel, Long lastEventId) {
     try {
-      replayMissedEventsIfNecessary(channel.memberId(), lastEventId);
       sendInstantEvent(
           channel.memberId(),
           SseEventType.HAND_SHAKE_COMPLETE,
-          "EventStream Created. userId: " + channel.memberId());
+          "EventStream Created. userId: " + channel.memberId(),
+          lastEventId);
+      replayMissedEventsIfNecessary(channel.memberId(), lastEventId);
     } catch (Exception e) {
       channel.completeWithError(e);
     }
@@ -80,26 +81,31 @@ public class NotificationEventService implements NotificationEventPublicApi {
     notificationChannelRepository.findById(userId).ifPresent(channel -> channel.send(eventData));
   }
 
-  private void sendInstantEvent(Long userId, SseEventType eventType, Object data) {
-    EventData eventData = EventData.of(userId, eventType.code(), data);
+  private void sendInstantEvent(
+      Long userId, SseEventType eventType, Object data, Long lastEventId) {
+    EventData eventData;
+    if (eventType == SseEventType.HAND_SHAKE_COMPLETE && lastEventId != null) {
+      eventData = EventData.reConnection(userId, lastEventId);
+    } else {
+      eventData = EventData.of(userId, eventType.code(), data);
+    }
     notificationChannelRepository.findById(userId).ifPresent(channel -> channel.send(eventData));
   }
 
-  private void replayMissedEventsIfNecessary(Long userId, String lastEventId) {
-    if (lastEventId == null || lastEventId.isEmpty()) {
+  private void replayMissedEventsIfNecessary(Long userId, Long lastEventId) {
+    if (lastEventId == null) {
       return;
     }
     log.info("Reconnecting user {} with lastEventId: {}", userId, lastEventId);
     doReplayMissedEvents(userId, lastEventId);
   }
 
-  private void doReplayMissedEvents(Long userId, String lastEventId) {
+  private void doReplayMissedEvents(Long userId, Long lastId) {
     try {
-      long lastId = Long.parseLong(lastEventId);
       List<EventData> missedEvents = sseEventCache.pollAllByUserIdAfter(userId, lastId);
       replayFoundEvents(userId, missedEvents);
     } catch (NumberFormatException e) {
-      log.warn("Invalid lastEventId format: {} for user {}", lastEventId, userId);
+      log.warn("Invalid lastEventId format: {} for user {}", lastId, userId);
     }
   }
 

--- a/src/main/java/kr/it/pullit/modules/notification/service/NotificationEventService.java
+++ b/src/main/java/kr/it/pullit/modules/notification/service/NotificationEventService.java
@@ -71,6 +71,7 @@ public class NotificationEventService implements NotificationEventPublicApi {
           channel.memberId(),
           SseEventType.HAND_SHAKE_COMPLETE,
           "EventStream Created. userId: " + channel.memberId());
+      sseEventCache.clearByUserId(channel.memberId());
     } catch (Exception e) {
       channel.completeWithError(e);
     }

--- a/src/main/java/kr/it/pullit/modules/notification/web/NotificationController.java
+++ b/src/main/java/kr/it/pullit/modules/notification/web/NotificationController.java
@@ -27,6 +27,8 @@ public class NotificationController {
 
     String lastEventId = headerLastEventId != null ? headerLastEventId : paramLastEventId;
 
-    return notificationEventPublicApi.subscribe(memberId, lastEventId);
+    Long lastEventIdLong = lastEventId != null ? Long.parseLong(lastEventId) : null;
+
+    return notificationEventPublicApi.subscribe(memberId, lastEventIdLong);
   }
 }

--- a/src/main/java/kr/it/pullit/modules/questionset/event/QuestionGenerationEventHandler.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/event/QuestionGenerationEventHandler.java
@@ -126,7 +126,8 @@ public class QuestionGenerationEventHandler {
     QuestionSetResponse questionSetResponse =
         questionSetPublicApi.getQuestionSetForSolving(
             event.questionSetId(), event.ownerId(), false);
-    return new QuestionSetCreationCompleteResponse(true, questionSetResponse.getId(), "문제집 생성 완료");
+    return new QuestionSetCreationCompleteResponse(
+        true, questionSetResponse.getId(), "문제집 생성 완료 (" + questionSetResponse.getTitle() + ")");
   }
 
   private void publishSuccessNotification(


### PR DESCRIPTION
<!-- PR 제목을 `이슈번호: 작업내용(명확히)`로 작성해주세요. -->

## PR 설명

sse 중복 전송 해결했습니다.

## 기타 

- [x] cache 구조 map으로 변경
- [x] heartbeat id 삭제

<!--Release Notes:

- N/A _or_ Added/Fixed/Improved ...-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Heartbeat ping events added to keep live notification connections active.
  * Reconnection events to improve resume behavior after reconnects.

* **Improvements**
  * Notifications now use per-user queues, improving delivery reliability and replay of missed events.
  * Unseen events are retained per user until replayed, reducing missed notifications.
  * Success message for question-set creation now includes the generated title.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->