### PR TITLE
btsk-105: learnstat response 반영 및 markresult로직 수정

### DIFF
--- a/src/main/java/kr/it/pullit/modules/projection/learnstats/web/dto/LearnStatsResponse.java
+++ b/src/main/java/kr/it/pullit/modules/projection/learnstats/web/dto/LearnStatsResponse.java
@@ -1,6 +1,7 @@
 package kr.it.pullit.modules.projection.learnstats.web.dto;
 
 import jakarta.validation.constraints.PositiveOrZero;
+import java.time.LocalDate;
 import kr.it.pullit.modules.projection.learnstats.domain.LearnStats;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -15,14 +16,16 @@ import lombok.NoArgsConstructor;
 public class LearnStatsResponse {
 
   @PositiveOrZero private int totalQuestionSetCount; // 총 문제집 수
-
   @PositiveOrZero private int totalSolvedQuestionSetCount; // 완료한 문제집 수
 
+  @PositiveOrZero private long totalQuestionCount; // 전체 문제 수
   @PositiveOrZero private long totalSolvedQuestionCount; // 총 푼 문제 수
 
   @PositiveOrZero private int weeklySolvedQuestionCount; // 이번 주 푼 문제 수
 
   @PositiveOrZero private int consecutiveLearningDays; // 연속 학습일
+
+  private LocalDate lastLearningDate; // 마지막 학습일(처음은 null)
 
   public static LearnStatsResponse of(LearnStats p, int totalQuestionSetCount) {
     if (p == null) {
@@ -31,9 +34,11 @@ public class LearnStatsResponse {
     return LearnStatsResponse.builder()
         .totalQuestionSetCount(totalQuestionSetCount)
         .totalSolvedQuestionSetCount(p.getTotalSolvedQuestionSetCount())
+        .totalQuestionCount(p.getTotalQuestionCount())
         .totalSolvedQuestionCount(p.getTotalSolvedQuestionCount())
         .weeklySolvedQuestionCount(p.getWeeklySolvedQuestionCount())
         .consecutiveLearningDays(p.getConsecutiveLearningDays())
+        .lastLearningDate(p.getLastLearningDate())
         .build();
   }
 

--- a/src/main/java/kr/it/pullit/modules/questionset/repository/MarkingResultRepository.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/repository/MarkingResultRepository.java
@@ -5,7 +5,7 @@ import kr.it.pullit.modules.questionset.domain.entity.MarkingResult;
 public interface MarkingResultRepository {
   MarkingResult save(MarkingResult markingResult);
 
-  long countByMemberIdAndIsCorrectIsTrue(Long memberId);
-
   long countByQuestionSetIdAndMemberId(Long questionSetId, Long memberId);
+
+  long countCorrectByQuestionSetIdAndMemberId(Long questionSetId, Long memberId);
 }

--- a/src/main/java/kr/it/pullit/modules/questionset/repository/MarkingResultRepositoryImpl.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/repository/MarkingResultRepositoryImpl.java
@@ -17,12 +17,13 @@ public class MarkingResultRepositoryImpl implements MarkingResultRepository {
   }
 
   @Override
-  public long countByMemberIdAndIsCorrectIsTrue(Long memberId) {
-    return jpaRepository.countByMemberIdAndIsCorrectIsTrue(memberId);
+  public long countByQuestionSetIdAndMemberId(Long questionSetId, Long memberId) {
+    return jpaRepository.countByQuestion_QuestionSetIdAndMemberId(questionSetId, memberId);
   }
 
   @Override
-  public long countByQuestionSetIdAndMemberId(Long questionSetId, Long memberId) {
-    return jpaRepository.countByQuestion_QuestionSetIdAndMemberId(questionSetId, memberId);
+  public long countCorrectByQuestionSetIdAndMemberId(Long questionSetId, Long memberId) {
+    return jpaRepository.countByQuestion_QuestionSetIdAndMemberIdAndIsCorrectIsTrue(
+        questionSetId, memberId);
   }
 }

--- a/src/main/java/kr/it/pullit/modules/questionset/repository/adapter/jpa/MarkingResultJpaRepository.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/repository/adapter/jpa/MarkingResultJpaRepository.java
@@ -5,7 +5,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MarkingResultJpaRepository extends JpaRepository<MarkingResult, Long> {
 
-  long countByMemberIdAndIsCorrectIsTrue(Long memberId);
-
   long countByQuestion_QuestionSetIdAndMemberId(Long questionSetId, Long memberId);
+
+  long countByQuestion_QuestionSetIdAndMemberIdAndIsCorrectIsTrue(
+      Long questionSetId, Long memberId);
 }

--- a/src/main/java/kr/it/pullit/modules/questionset/service/MarkingService.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/service/MarkingService.java
@@ -55,9 +55,21 @@ public class MarkingService implements MarkingPublicApi {
   }
 
   private void updateQuestionSetLearningStatus(Long memberId, QuestionSet questionSet) {
-    long attemptedQuestionCount =
-        markingResultRepository.countByQuestionSetIdAndMemberId(questionSet.getId(), memberId);
-    questionSet.updateLearningStatus(attemptedQuestionCount);
+    long correctQuestionCount =
+        markingResultRepository.countCorrectByQuestionSetIdAndMemberId(
+            questionSet.getId(), memberId);
+
+    if (correctQuestionCount == 0) {
+      long attemptedQuestionCount =
+          markingResultRepository.countByQuestionSetIdAndMemberId(questionSet.getId(), memberId);
+      if (attemptedQuestionCount > 0) {
+        questionSet.updateLearningStatus(1);
+        questionSetRepository.save(questionSet);
+        return;
+      }
+    }
+
+    questionSet.updateLearningStatus(correctQuestionCount);
     questionSetRepository.save(questionSet);
   }
 


### PR DESCRIPTION
<!-- PR 제목을 `이슈번호: 작업내용(명확히)`로 작성해주세요. -->

## PR 설명

learnstat response 반영 및 markresult로직 올바르게 수정

<!--Release Notes:

- N/A _or_ Added/Fixed/Improved ...-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Improved accuracy of learning statistics calculations to properly track and measure progress by individual question set.
  * Refined learning status tracking to reflect correct answer counts instead of total attempts, providing more accurate progress measurement.
  * Enhanced statistics tracking with added support for recording total question counts and last learning activity date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->