### PR TITLE
btsk-104: redis refresh token에 적용

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,17 @@ on:
 jobs:
   code_check:
     runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     env:
       AWS_REGION: ap-northeast-2
       # DB 관련 변수는 빌드/테스트 시 내장 DB를 사용하므로 불필요

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,13 @@ jobs:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: junit-report
+          path: build/reports/tests/test
+
       - name: Build and push image with tags (latest and sha)
         if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
         uses: docker/build-push-action@v5

--- a/build.gradle
+++ b/build.gradle
@@ -123,6 +123,7 @@ dependencies {
 
     // AOP 및 개발 도구
     implementation 'org.springframework.boot:spring-boot-starter-aop'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,3 +8,7 @@ services:
       - 'MARIADB_USER=myuser'
     ports:
       - "127.0.0.1:3306:3306"
+  redis:
+    image: 'redis:8.0.4-alpine'
+    ports:
+      - "127.0.0.1:6379:6379"

--- a/docker-compose.qa.yml
+++ b/docker-compose.qa.yml
@@ -26,9 +26,14 @@ services:
       - SENTRY_AUTH_TOKEN=${SENTRY_AUTH_TOKEN}
       # JVM 옵션 (메모리 최적화)
       - JAVA_OPTS=-Xmx512m -Xms256m
+      # Redis 연결 설정
+      - REDIS_HOST=pullit-qa-redis
+      - REDIS_PORT=6379
     depends_on:
       pullit-qa-db:
         condition: service_healthy
+      pullit-qa-redis:
+        condition: service_started
     networks:
       - pullit-qa-network
     healthcheck:
@@ -67,6 +72,21 @@ services:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
       - --default-time-zone=+09:00
+
+  # QA용 Redis
+  pullit-qa-redis:
+    image: redis:8.0.4-alpine
+    container_name: pullit-qa-redis
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+    networks:
+      - pullit-qa-network
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
 volumes:
   pullit_qa_data:

--- a/src/main/java/kr/it/pullit/configuration/RedisConfig.java
+++ b/src/main/java/kr/it/pullit/configuration/RedisConfig.java
@@ -13,32 +13,32 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @EnableRedisRepositories(basePackages = "kr.it.pullit.modules.auth.repository")
 public class RedisConfig {
 
-    @Value("${spring.data.redis.host}")
-    private String host;
+  @Value("${spring.data.redis.host}")
+  private String host;
 
-    @Value("${spring.data.redis.port}")
-    private int port;
+  @Value("${spring.data.redis.port}")
+  private int port;
 
-    @Bean
-    public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory(host, port);
-    }
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory() {
+    return new LettuceConnectionFactory(host, port);
+  }
 
-    @Bean
-    public RedisTemplate<String, Object> redisTemplate() {
-        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(redisConnectionFactory());
+  @Bean
+  public RedisTemplate<String, Object> redisTemplate() {
+    RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setConnectionFactory(redisConnectionFactory());
 
-        // 일반적인 key:value의 경우 시리얼라이저
-        redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new StringRedisSerializer());
+    // 일반적인 key:value의 경우 시리얼라이저
+    redisTemplate.setKeySerializer(new StringRedisSerializer());
+    redisTemplate.setValueSerializer(new StringRedisSerializer());
 
-        // Hash를 사용할 경우 시리얼라이저
-        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
-        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+    // Hash를 사용할 경우 시리얼라이저
+    redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+    redisTemplate.setHashValueSerializer(new StringRedisSerializer());
 
-        // 모든 경우
-        redisTemplate.setDefaultSerializer(new StringRedisSerializer());
-        return redisTemplate;
-    }
+    // 모든 경우
+    redisTemplate.setDefaultSerializer(new StringRedisSerializer());
+    return redisTemplate;
+  }
 }

--- a/src/main/java/kr/it/pullit/configuration/RedisConfig.java
+++ b/src/main/java/kr/it/pullit/configuration/RedisConfig.java
@@ -1,0 +1,44 @@
+package kr.it.pullit.configuration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories(basePackages = "kr.it.pullit.modules.auth.repository")
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        // 일반적인 key:value의 경우 시리얼라이저
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        // Hash를 사용할 경우 시리얼라이저
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+
+        // 모든 경우
+        redisTemplate.setDefaultSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/kr/it/pullit/modules/auth/domain/entity/RefreshToken.java
+++ b/src/main/java/kr/it/pullit/modules/auth/domain/entity/RefreshToken.java
@@ -1,13 +1,13 @@
 package kr.it.pullit.modules.auth.domain.entity;
 
-import org.springframework.data.annotation.Id;
-import org.springframework.data.redis.core.RedisHash;
-import org.springframework.data.redis.core.TimeToLive;
-import org.springframework.data.redis.core.index.Indexed;
 import kr.it.pullit.modules.member.domain.entity.Role;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+import org.springframework.data.redis.core.index.Indexed;
 
 @Getter
 @NoArgsConstructor
@@ -15,21 +15,18 @@ import lombok.NoArgsConstructor;
 @RedisHash("refreshToken")
 public class RefreshToken {
 
-    @Id
-    private Long memberId;
+  @Id private Long memberId;
 
-    @Indexed
-    private String token;
+  @Indexed private String token;
 
-    private String email;
+  private String email;
 
-    private String role;
+  private String role;
 
-    @TimeToLive
-    private Long expiration;
+  @TimeToLive private Long expiration;
 
-    public static RefreshToken of(
-            Long memberId, String token, String email, Role role, Long expiration) {
-        return new RefreshToken(memberId, token, email, role.name(), expiration);
-    }
+  public static RefreshToken of(
+      Long memberId, String token, String email, Role role, Long expiration) {
+    return new RefreshToken(memberId, token, email, role.name(), expiration);
+  }
 }

--- a/src/main/java/kr/it/pullit/modules/auth/domain/entity/RefreshToken.java
+++ b/src/main/java/kr/it/pullit/modules/auth/domain/entity/RefreshToken.java
@@ -1,0 +1,35 @@
+package kr.it.pullit.modules.auth.domain.entity;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+import org.springframework.stereotype.Indexed;
+import kr.it.pullit.modules.member.domain.entity.Role;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@RedisHash("refreshToken")
+public class RefreshToken {
+
+    @Id
+    private Long memberId;
+
+    @Indexed
+    private String token;
+
+    private String email;
+
+    private String role;
+
+    @TimeToLive
+    private Long expiration;
+
+    public static RefreshToken of(
+            Long memberId, String token, String email, Role role, Long expiration) {
+        return new RefreshToken(memberId, token, email, role.name(), expiration);
+    }
+}

--- a/src/main/java/kr/it/pullit/modules/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/kr/it/pullit/modules/auth/repository/RefreshTokenRepository.java
@@ -1,9 +1,9 @@
 package kr.it.pullit.modules.auth.repository;
 
 import java.util.Optional;
-import org.springframework.data.repository.CrudRepository;
 import kr.it.pullit.modules.auth.domain.entity.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
 
 public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {
-    Optional<RefreshToken> findByToken(String token);
+  Optional<RefreshToken> findByToken(String token);
 }

--- a/src/main/java/kr/it/pullit/modules/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/kr/it/pullit/modules/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,9 @@
+package kr.it.pullit.modules.auth.repository;
+
+import java.util.Optional;
+import org.springframework.data.repository.CrudRepository;
+import kr.it.pullit.modules.auth.domain.entity.RefreshToken;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByToken(String token);
+}

--- a/src/main/java/kr/it/pullit/modules/auth/service/AuthService.java
+++ b/src/main/java/kr/it/pullit/modules/auth/service/AuthService.java
@@ -1,16 +1,20 @@
 package kr.it.pullit.modules.auth.service;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import kr.it.pullit.modules.auth.domain.entity.RefreshToken;
 import kr.it.pullit.modules.auth.exception.InvalidRefreshTokenException;
+import kr.it.pullit.modules.auth.repository.RefreshTokenRepository;
 import kr.it.pullit.modules.member.api.MemberPublicApi;
 import kr.it.pullit.modules.member.domain.entity.Member;
+import kr.it.pullit.modules.member.domain.entity.Role;
 import kr.it.pullit.modules.member.exception.MemberNotFoundException;
+import kr.it.pullit.platform.security.jwt.JwtProps;
 import kr.it.pullit.platform.security.jwt.JwtTokenProvider;
 import kr.it.pullit.platform.security.jwt.dto.AuthTokens;
 import kr.it.pullit.platform.security.jwt.dto.TokenCreationSubject;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -19,6 +23,8 @@ public class AuthService {
 
   private final MemberPublicApi memberPublicApi;
   private final JwtTokenProvider jwtTokenProvider;
+  private final RefreshTokenRepository refreshTokenRepository;
+  private final JwtProps jwtProps;
 
   @Transactional
   public AuthTokens issueAndSaveTokens(Long memberId) {
@@ -28,11 +34,19 @@ public class AuthService {
             .orElseThrow(() -> MemberNotFoundException.byId(memberId));
 
     AuthTokens newAuthTokens = jwtTokenProvider.createAuthTokens(TokenCreationSubject.from(member));
-    member.updateRefreshToken(newAuthTokens.refreshToken());
-
-    log.info(" [토큰 발급] DB에 저장된 리프레시 토큰: {}", newAuthTokens.refreshToken());
+    storeRefreshToken(member, newAuthTokens.refreshToken());
 
     return newAuthTokens;
+  }
+
+  public void storeRefreshToken(Member member, String refreshToken) {
+    long ttl = jwtProps.refreshTokenExpirationDays().toMillis();
+
+    RefreshToken tokenEntity =
+        RefreshToken.of(
+            member.getId(), refreshToken, member.getEmail(), member.getRole(), ttl);
+    refreshTokenRepository.save(tokenEntity);
+    log.info(" [리프레시 토큰 저장] Redis Key(memberId): {}", member.getId());
   }
 
   @Transactional(readOnly = true)
@@ -40,21 +54,24 @@ public class AuthService {
     log.info(" [토큰 갱신] API로 전달받은 리프레시 토큰: {}", refreshToken);
     validateRefreshToken(refreshToken);
 
-    Member member =
-        memberPublicApi
-            .findByRefreshToken(refreshToken)
+    RefreshToken tokenEntity =
+        refreshTokenRepository
+            .findByToken(refreshToken)
             .orElseThrow(InvalidRefreshTokenException::by);
 
-    return jwtTokenProvider.createAccessToken(TokenCreationSubject.from(member));
+    TokenCreationSubject subject =
+        TokenCreationSubject.of(
+            tokenEntity.getMemberId(),
+            tokenEntity.getEmail(),
+            Role.valueOf(tokenEntity.getRole()));
+
+    return jwtTokenProvider.createAccessToken(subject);
   }
 
   @Transactional
   public void logout(Long memberId) {
-    Member member =
-        memberPublicApi
-            .findById(memberId)
-            .orElseThrow(() -> MemberNotFoundException.byId(memberId));
-    member.updateRefreshToken(null);
+    refreshTokenRepository.deleteById(memberId);
+    log.info(" [로그아웃] Redis에서 리프레시 토큰 삭제 완료. Key(memberId): {}", memberId);
   }
 
   private void validateRefreshToken(String refreshToken) {

--- a/src/main/java/kr/it/pullit/modules/auth/service/AuthService.java
+++ b/src/main/java/kr/it/pullit/modules/auth/service/AuthService.java
@@ -1,7 +1,5 @@
 package kr.it.pullit.modules.auth.service;
 
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import kr.it.pullit.modules.auth.domain.entity.RefreshToken;
 import kr.it.pullit.modules.auth.exception.InvalidRefreshTokenException;
 import kr.it.pullit.modules.auth.repository.RefreshTokenRepository;
@@ -15,6 +13,8 @@ import kr.it.pullit.platform.security.jwt.dto.AuthTokens;
 import kr.it.pullit.platform.security.jwt.dto.TokenCreationSubject;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service

--- a/src/main/java/kr/it/pullit/modules/auth/service/AuthService.java
+++ b/src/main/java/kr/it/pullit/modules/auth/service/AuthService.java
@@ -1,5 +1,7 @@
 package kr.it.pullit.modules.auth.service;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import kr.it.pullit.modules.auth.domain.entity.RefreshToken;
 import kr.it.pullit.modules.auth.exception.InvalidRefreshTokenException;
 import kr.it.pullit.modules.auth.repository.RefreshTokenRepository;
@@ -13,8 +15,6 @@ import kr.it.pullit.platform.security.jwt.dto.AuthTokens;
 import kr.it.pullit.platform.security.jwt.dto.TokenCreationSubject;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -40,7 +40,7 @@ public class AuthService {
   }
 
   public void storeRefreshToken(Member member, String refreshToken) {
-    long ttl = jwtProps.refreshTokenExpirationDays().toMillis();
+    long ttl = jwtProps.refreshTokenExpirationDays().toSeconds();
 
     RefreshToken tokenEntity =
         RefreshToken.of(member.getId(), refreshToken, member.getEmail(), member.getRole(), ttl);

--- a/src/main/java/kr/it/pullit/modules/auth/service/AuthService.java
+++ b/src/main/java/kr/it/pullit/modules/auth/service/AuthService.java
@@ -1,7 +1,5 @@
 package kr.it.pullit.modules.auth.service;
 
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import kr.it.pullit.modules.auth.domain.entity.RefreshToken;
 import kr.it.pullit.modules.auth.exception.InvalidRefreshTokenException;
 import kr.it.pullit.modules.auth.repository.RefreshTokenRepository;
@@ -15,6 +13,8 @@ import kr.it.pullit.platform.security.jwt.dto.AuthTokens;
 import kr.it.pullit.platform.security.jwt.dto.TokenCreationSubject;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -43,8 +43,7 @@ public class AuthService {
     long ttl = jwtProps.refreshTokenExpirationDays().toMillis();
 
     RefreshToken tokenEntity =
-        RefreshToken.of(
-            member.getId(), refreshToken, member.getEmail(), member.getRole(), ttl);
+        RefreshToken.of(member.getId(), refreshToken, member.getEmail(), member.getRole(), ttl);
     refreshTokenRepository.save(tokenEntity);
     log.info(" [리프레시 토큰 저장] Redis Key(memberId): {}", member.getId());
   }
@@ -61,9 +60,7 @@ public class AuthService {
 
     TokenCreationSubject subject =
         TokenCreationSubject.of(
-            tokenEntity.getMemberId(),
-            tokenEntity.getEmail(),
-            Role.valueOf(tokenEntity.getRole()));
+            tokenEntity.getMemberId(), tokenEntity.getEmail(), Role.valueOf(tokenEntity.getRole()));
 
     return jwtTokenProvider.createAccessToken(subject);
   }

--- a/src/main/java/kr/it/pullit/modules/auth/web/AuthController.java
+++ b/src/main/java/kr/it/pullit/modules/auth/web/AuthController.java
@@ -1,11 +1,5 @@
 package kr.it.pullit.modules.auth.web;
 
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.it.pullit.modules.auth.service.AuthService;
 import kr.it.pullit.modules.auth.web.apidocs.AuthApiDocs;
@@ -14,6 +8,12 @@ import kr.it.pullit.modules.auth.web.apidocs.ReissueTokenApiDocs;
 import kr.it.pullit.modules.auth.web.dto.AccessTokenResponse;
 import kr.it.pullit.platform.aop.annotation.ClearCookie;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Auth API", description = "인증 및 토큰 관련 API")
 @RequiredArgsConstructor

--- a/src/main/java/kr/it/pullit/modules/auth/web/AuthController.java
+++ b/src/main/java/kr/it/pullit/modules/auth/web/AuthController.java
@@ -1,5 +1,11 @@
 package kr.it.pullit.modules.auth.web;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.it.pullit.modules.auth.service.AuthService;
 import kr.it.pullit.modules.auth.web.apidocs.AuthApiDocs;
@@ -8,12 +14,6 @@ import kr.it.pullit.modules.auth.web.apidocs.ReissueTokenApiDocs;
 import kr.it.pullit.modules.auth.web.dto.AccessTokenResponse;
 import kr.it.pullit.platform.aop.annotation.ClearCookie;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Auth API", description = "인증 및 토큰 관련 API")
 @RequiredArgsConstructor

--- a/src/main/java/kr/it/pullit/modules/member/api/MemberPublicApi.java
+++ b/src/main/java/kr/it/pullit/modules/member/api/MemberPublicApi.java
@@ -1,11 +1,11 @@
 package kr.it.pullit.modules.member.api;
 
 import java.util.Optional;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import kr.it.pullit.modules.member.domain.entity.Member;
 import kr.it.pullit.modules.member.service.dto.SocialLoginCommand;
 import kr.it.pullit.modules.member.web.dto.MemberInfoResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface MemberPublicApi {
 

--- a/src/main/java/kr/it/pullit/modules/member/domain/entity/Member.java
+++ b/src/main/java/kr/it/pullit/modules/member/domain/entity/Member.java
@@ -1,7 +1,5 @@
 package kr.it.pullit.modules.member.domain.entity;
 
-import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -15,6 +13,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 @Entity
 @Getter

--- a/src/main/java/kr/it/pullit/modules/member/domain/entity/Member.java
+++ b/src/main/java/kr/it/pullit/modules/member/domain/entity/Member.java
@@ -1,5 +1,7 @@
 package kr.it.pullit.modules.member.domain.entity;
 
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -13,8 +15,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
 
 @Entity
 @Getter
@@ -33,9 +33,6 @@ public class Member extends BaseEntity {
   private String email;
 
   @Column private String name;
-
-  @Column(length = 512)
-  private String refreshToken;
 
   @Enumerated(EnumType.STRING)
   @Column
@@ -82,10 +79,6 @@ public class Member extends BaseEntity {
         .status(MemberStatus.ACTIVE)
         .role(Role.ADMIN)
         .build();
-  }
-
-  public void updateRefreshToken(String refreshToken) {
-    this.refreshToken = refreshToken;
   }
 
   public void linkKakaoId(Long kakaoId) {

--- a/src/main/java/kr/it/pullit/modules/member/repository/MemberRepository.java
+++ b/src/main/java/kr/it/pullit/modules/member/repository/MemberRepository.java
@@ -1,9 +1,9 @@
 package kr.it.pullit.modules.member.repository;
 
 import java.util.Optional;
+import kr.it.pullit.modules.member.domain.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import kr.it.pullit.modules.member.domain.entity.Member;
 
 public interface MemberRepository {
 

--- a/src/main/java/kr/it/pullit/modules/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/kr/it/pullit/modules/member/repository/MemberRepositoryImpl.java
@@ -1,12 +1,12 @@
 package kr.it.pullit.modules.member.repository;
 
 import java.util.Optional;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Repository;
 import kr.it.pullit.modules.member.domain.entity.Member;
 import kr.it.pullit.modules.member.repository.adapter.jpa.MemberJpaRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor

--- a/src/main/java/kr/it/pullit/modules/member/repository/adapter/jpa/MemberJpaRepository.java
+++ b/src/main/java/kr/it/pullit/modules/member/repository/adapter/jpa/MemberJpaRepository.java
@@ -1,8 +1,8 @@
 package kr.it.pullit.modules.member.repository.adapter.jpa;
 
 import java.util.Optional;
-import org.springframework.data.jpa.repository.JpaRepository;
 import kr.it.pullit.modules.member.domain.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberJpaRepository extends JpaRepository<Member, Long> {
 

--- a/src/main/java/kr/it/pullit/modules/member/service/MemberService.java
+++ b/src/main/java/kr/it/pullit/modules/member/service/MemberService.java
@@ -1,10 +1,6 @@
 package kr.it.pullit.modules.member.service;
 
 import java.util.Optional;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import kr.it.pullit.modules.auth.repository.RefreshTokenRepository;
 import kr.it.pullit.modules.commonfolder.api.CommonFolderPublicApi;
 import kr.it.pullit.modules.member.api.MemberPublicApi;
@@ -14,6 +10,10 @@ import kr.it.pullit.modules.member.repository.MemberRepository;
 import kr.it.pullit.modules.member.service.dto.SocialLoginCommand;
 import kr.it.pullit.modules.member.web.dto.MemberInfoResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional

--- a/src/main/java/kr/it/pullit/modules/member/service/MemberService.java
+++ b/src/main/java/kr/it/pullit/modules/member/service/MemberService.java
@@ -1,7 +1,6 @@
 package kr.it.pullit.modules.member.service;
 
 import java.util.Optional;
-import kr.it.pullit.modules.auth.repository.RefreshTokenRepository;
 import kr.it.pullit.modules.commonfolder.api.CommonFolderPublicApi;
 import kr.it.pullit.modules.member.api.MemberPublicApi;
 import kr.it.pullit.modules.member.domain.entity.Member;
@@ -21,7 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService implements MemberPublicApi {
 
   private final MemberRepository memberRepository;
-  private final RefreshTokenRepository refreshTokenRepository;
   private final CommonFolderPublicApi commonFolderPublicApi;
 
   @Override
@@ -46,11 +44,9 @@ public class MemberService implements MemberPublicApi {
     }
 
     Optional<Member> byEmail = memberRepository.findByEmail(command.email());
-    if (byEmail.isPresent()) {
-      return linkKakaoToExistingEmailMember(byEmail.get(), command);
-    }
+    return byEmail.map(member -> linkKakaoToExistingEmailMember(member, command))
+        .orElseGet(() -> createNewMember(command));
 
-    return createNewMember(command);
   }
 
   @Override

--- a/src/main/java/kr/it/pullit/modules/member/service/MemberService.java
+++ b/src/main/java/kr/it/pullit/modules/member/service/MemberService.java
@@ -44,9 +44,9 @@ public class MemberService implements MemberPublicApi {
     }
 
     Optional<Member> byEmail = memberRepository.findByEmail(command.email());
-    return byEmail.map(member -> linkKakaoToExistingEmailMember(member, command))
+    return byEmail
+        .map(member -> linkKakaoToExistingEmailMember(member, command))
         .orElseGet(() -> createNewMember(command));
-
   }
 
   @Override

--- a/src/main/resources/application-qa.yml
+++ b/src/main/resources/application-qa.yml
@@ -1,4 +1,8 @@
 spring:
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}

--- a/src/test/java/kr/it/pullit/modules/auth/repository/RefreshTokenRepositoryTest.java
+++ b/src/test/java/kr/it/pullit/modules/auth/repository/RefreshTokenRepositoryTest.java
@@ -1,0 +1,41 @@
+package kr.it.pullit.modules.auth.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import kr.it.pullit.modules.auth.domain.entity.RefreshToken;
+import kr.it.pullit.modules.member.domain.entity.Role;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
+
+@DataRedisTest
+@DisplayName("RefreshTokenRepository 슬라이스 테스트")
+class RefreshTokenRepositoryTest {
+
+  @Autowired private RefreshTokenRepository refreshTokenRepository;
+
+  @Test
+  @DisplayName("RefreshToken을 저장하고 토큰 값으로 조회하면, 저장된 토큰이 조회되어야 한다")
+  void shouldSaveAndFindRefreshTokenByToken() {
+    // given
+    long memberId = 1L;
+    String tokenValue = "test-refresh-token";
+    String email = "test@example.com";
+    Role role = Role.MEMBER;
+    long expiration = 1000L;
+
+    RefreshToken refreshToken = RefreshToken.of(memberId, tokenValue, email, role, expiration);
+
+    // when
+    refreshTokenRepository.save(refreshToken);
+    RefreshToken foundToken = refreshTokenRepository.findByToken(tokenValue).orElse(null);
+
+    // then
+    assertThat(foundToken).isNotNull();
+    assertThat(foundToken.getMemberId()).isEqualTo(memberId);
+    assertThat(foundToken.getToken()).isEqualTo(tokenValue);
+    assertThat(foundToken.getEmail()).isEqualTo(email);
+    assertThat(foundToken.getRole()).isEqualTo(role.name());
+  }
+}

--- a/src/test/java/kr/it/pullit/modules/learningsource/source/service/SourceService2Test.java
+++ b/src/test/java/kr/it/pullit/modules/learningsource/source/service/SourceService2Test.java
@@ -3,27 +3,26 @@ package kr.it.pullit.modules.learningsource.source.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
-
-import com.sun.net.httpserver.HttpExchange;
-import com.sun.net.httpserver.HttpHandler;
-import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
 import kr.it.pullit.modules.learningsource.source.api.SourcePublicApi;
 import kr.it.pullit.modules.learningsource.source.web.dto.SourceUploadResponse;
 import kr.it.pullit.platform.storage.api.S3PublicApi;
 import kr.it.pullit.platform.storage.s3.dto.PresignedUrlResponse;
 import kr.it.pullit.support.annotation.IntegrationTest;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-@ActiveProfiles({"mock-auth", "real-env"})
+@ActiveProfiles({"mock-auth", "real-env", "test"})
 @IntegrationTest
 public class SourceService2Test {
 

--- a/src/test/java/kr/it/pullit/modules/learningsource/source/service/SourceService2Test.java
+++ b/src/test/java/kr/it/pullit/modules/learningsource/source/service/SourceService2Test.java
@@ -3,24 +3,25 @@ package kr.it.pullit.modules.learningsource.source.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import com.sun.net.httpserver.HttpExchange;
-import com.sun.net.httpserver.HttpHandler;
-import com.sun.net.httpserver.HttpServer;
 import kr.it.pullit.modules.learningsource.source.api.SourcePublicApi;
 import kr.it.pullit.modules.learningsource.source.web.dto.SourceUploadResponse;
 import kr.it.pullit.platform.storage.api.S3PublicApi;
 import kr.it.pullit.platform.storage.s3.dto.PresignedUrlResponse;
 import kr.it.pullit.support.annotation.IntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @ActiveProfiles({"mock-auth", "real-env", "test"})
 @IntegrationTest

--- a/src/test/java/kr/it/pullit/modules/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/kr/it/pullit/modules/member/repository/MemberRepositoryTest.java
@@ -31,8 +31,6 @@ class MemberRepositoryTest {
                 .name("tester")
                 .kakaoId(12345L)
                 .build());
-    savedMember.updateRefreshToken("test-refresh-token");
-    memberRepository.save(savedMember);
   }
 
   @Nested
@@ -70,17 +68,6 @@ class MemberRepositoryTest {
       // then
       assertThat(foundMember).isPresent();
       assertThat(foundMember.get().getKakaoId()).isEqualTo(12345L);
-    }
-
-    @Test
-    @DisplayName("리프레시 토큰으로 회원을 조회하면, 저장된 회원이 조회되어야 한다")
-    void shouldFindMemberByRefreshToken() {
-      // when
-      Optional<Member> foundMember = memberRepository.findByRefreshToken("test-refresh-token");
-
-      // then
-      assertThat(foundMember).isPresent();
-      assertThat(foundMember.get().getRefreshToken()).isEqualTo("test-refresh-token");
     }
 
     @Test

--- a/src/test/java/kr/it/pullit/support/clock/MutableClock.java
+++ b/src/test/java/kr/it/pullit/support/clock/MutableClock.java
@@ -33,4 +33,3 @@ public class MutableClock extends Clock {
     this.instant = instant;
   }
 }
-

--- a/src/test/java/kr/it/pullit/support/clock/MutableClock.java
+++ b/src/test/java/kr/it/pullit/support/clock/MutableClock.java
@@ -33,3 +33,4 @@ public class MutableClock extends Clock {
     this.instant = instant;
   }
 }
+

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -4,3 +4,7 @@ spring:
       mode: never
   datasource:
     url: jdbc:h2:mem:test;MODE=MySQL;
+  data:
+    redis:
+      host: localhost
+      port: 6379


### PR DESCRIPTION
<!-- PR 제목을 `이슈번호: 작업내용(명확히)`로 작성해주세요. -->

## PR 설명

redis refresh token에 적용

<!--Release Notes:

- N/A _or_ Added/Fixed/Improved ...-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redis-backed refresh token storage for improved session management.

* **Chores**
  * Added Redis dependency and environment/configuration for QA/test.
  * Added Redis service to local/dev deployment with health checks.
  * Updated authentication flows to persist refresh tokens in Redis.

* **Tests**
  * Added repository tests for refresh token persistence and adjusted test profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->