### PR TITLE
btsk-109: 카카오로 리다이렉트하는 무한루프 로직 수정

### DIFF
--- a/src/main/java/kr/it/pullit/platform/security/config/AuthorizationRules.java
+++ b/src/main/java/kr/it/pullit/platform/security/config/AuthorizationRules.java
@@ -13,12 +13,16 @@ public final class AuthorizationRules {
     "/",
     "/api/health",
     "/api-docs.yaml",
+    "/login",
     "/login/oauth2/code/**",
-    "/oauth/authorize/**",
     "/oauth2/authorization/**",
     "/auth/refresh",
     "/auth/logout",
-    "/api/notifications/**"
+    "/api/notifications/**",
+    "/error",
+    "/favicon.ico",
+    "/swagger-ui/**",
+    "/v3/api-docs/**"
   };
 
   /** 기본 인증/인가 규칙을 적용 */

--- a/src/main/java/kr/it/pullit/platform/security/config/SecurityConfig.java
+++ b/src/main/java/kr/it/pullit/platform/security/config/SecurityConfig.java
@@ -1,14 +1,8 @@
 package kr.it.pullit.platform.security.config;
 
 import java.util.Optional;
-import kr.it.pullit.modules.auth.kakaoauth.service.CustomOAuth2UserService;
-import kr.it.pullit.platform.security.handler.OAuth2AuthenticationSuccessHandler;
-import kr.it.pullit.platform.security.jwt.exception.JwtAuthenticationEntryPoint;
-import kr.it.pullit.platform.security.jwt.filter.DevAuthenticationFilter;
-import kr.it.pullit.platform.security.jwt.filter.JwtAuthenticationFilter;
-import kr.it.pullit.platform.security.repository.OAuth2AuthorizationRequestRepository;
-import lombok.RequiredArgsConstructor;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -23,24 +17,27 @@ import org.springframework.security.web.authentication.AuthenticationFailureHand
 import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.util.UriComponentsBuilder;
+import kr.it.pullit.modules.auth.kakaoauth.service.CustomOAuth2UserService;
+import kr.it.pullit.platform.security.handler.OAuth2AuthenticationSuccessHandler;
+import kr.it.pullit.platform.security.jwt.exception.JwtAuthenticationEntryPoint;
+import kr.it.pullit.platform.security.jwt.filter.DevAuthenticationFilter;
+import kr.it.pullit.platform.security.jwt.filter.JwtAuthenticationFilter;
+import kr.it.pullit.platform.security.repository.OAuth2AuthorizationRequestRepository;
+import lombok.RequiredArgsConstructor;
 
 /**
- * 애플리케이션의 Spring Security 설정을 담당합니다.
- *
- * <p>활성화된 Spring 프로필(@Profile)에 따라 서로 다른 보안 필터 체인(SecurityFilterChain)을 구성하여, 인증/인가 정책을 환경별로 다르게
- * 적용합니다.
- *
- * <ul>
- *   <li><b>auth:</b> 인증이 필요한 운영 환경용 보안 설정을 적용합니다.
- *   <li><b>qa:</b> 인증을 비활성화하여 테스트 편의성을 높인 QA 환경용 설정을 적용합니다.
- *   <li><b>default (지정 없음):</b> 'auth' 또는 'qa' 프로필이 아닐 때 적용되는 기본 설정으로, 모든 요청을 허용합니다. (예: 로컬 개발 환경)
- * </ul>
+ * 활성화된 Spring 프로필에 따라 다른 보안 필터 체인(SecurityFilterChain)을 구성하여
+ * 인증/인가 정책을 환경별로 다르게 적용.
  */
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+  @Value("${app.oauth2.authorized-redirect-uri}")
+  private String authorizedRedirectUri;
 
   private final CustomOAuth2UserService customOAuth2UserService;
   private final CorsConfigurationSource corsConfigurationSource;
@@ -62,21 +59,29 @@ public class SecurityConfig {
     return http.build();
   }
 
-  private static final AuthenticationFailureHandler OAUTH2_FAILURE_HANDLER =
-      (request, response, ex) -> {
-        LoggerFactory.getLogger("OAuth2Failure")
-            .error(
-                "[OAUTH2_FAILURE] errorClass={}, message={}, state={}, redirectUriFromSession={}",
-                ex.getClass().getSimpleName(),
-                ex.getMessage(),
-                request.getParameter("state"),
-                request.getSession(false) == null
-                    ? null
-                    : request
-                        .getSession(false)
-                        .getAttribute(OAuth2AuthenticationSuccessHandler.REDIRECT_URI_SESSION_KEY));
-        response.sendRedirect("/login?error");
-      };
+  private AuthenticationFailureHandler oauth2FailureHandler() {
+    return (request, response, ex) -> {
+      LoggerFactory.getLogger("OAuth2Failure")
+          .error(
+              "[OAUTH2_FAILURE] errorClass={}, message={}, state={}, redirectUriFromSession={}",
+              ex.getClass().getSimpleName(),
+              ex.getMessage(),
+              request.getParameter("state"),
+              request.getSession(false) == null
+                  ? null
+                  : request
+                      .getSession(false)
+                      .getAttribute(OAuth2AuthenticationSuccessHandler.REDIRECT_URI_SESSION_KEY));
+
+      String targetUrl =
+          UriComponentsBuilder.fromUriString(authorizedRedirectUri)
+              .queryParam("error", ex.getLocalizedMessage())
+              .build()
+              .toUriString();
+
+      response.sendRedirect(targetUrl);
+    };
+  }
 
   private void applyCommon(HttpSecurity http) throws Exception {
     http.cors(cors -> cors.configurationSource(corsConfigurationSource))
@@ -95,7 +100,7 @@ public class SecurityConfig {
                             httpCookieOAuth2AuthorizationRequestRepository))
                 .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
                 .successHandler(oauth2AuthenticationSuccessHandler)
-                .failureHandler(OAUTH2_FAILURE_HANDLER));
+                .failureHandler(oauth2FailureHandler()));
   }
 
   @Bean

--- a/src/main/java/kr/it/pullit/platform/security/config/SecurityConfig.java
+++ b/src/main/java/kr/it/pullit/platform/security/config/SecurityConfig.java
@@ -1,6 +1,13 @@
 package kr.it.pullit.platform.security.config;
 
 import java.util.Optional;
+import kr.it.pullit.modules.auth.kakaoauth.service.CustomOAuth2UserService;
+import kr.it.pullit.platform.security.handler.OAuth2AuthenticationSuccessHandler;
+import kr.it.pullit.platform.security.jwt.exception.JwtAuthenticationEntryPoint;
+import kr.it.pullit.platform.security.jwt.filter.DevAuthenticationFilter;
+import kr.it.pullit.platform.security.jwt.filter.JwtAuthenticationFilter;
+import kr.it.pullit.platform.security.repository.OAuth2AuthorizationRequestRepository;
+import lombok.RequiredArgsConstructor;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -18,18 +25,8 @@ import org.springframework.security.web.authentication.LoginUrlAuthenticationEnt
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.util.UriComponentsBuilder;
-import kr.it.pullit.modules.auth.kakaoauth.service.CustomOAuth2UserService;
-import kr.it.pullit.platform.security.handler.OAuth2AuthenticationSuccessHandler;
-import kr.it.pullit.platform.security.jwt.exception.JwtAuthenticationEntryPoint;
-import kr.it.pullit.platform.security.jwt.filter.DevAuthenticationFilter;
-import kr.it.pullit.platform.security.jwt.filter.JwtAuthenticationFilter;
-import kr.it.pullit.platform.security.repository.OAuth2AuthorizationRequestRepository;
-import lombok.RequiredArgsConstructor;
 
-/**
- * 활성화된 Spring 프로필에 따라 다른 보안 필터 체인(SecurityFilterChain)을 구성하여
- * 인증/인가 정책을 환경별로 다르게 적용.
- */
+/** 활성화된 Spring 프로필에 따라 다른 보안 필터 체인(SecurityFilterChain)을 구성하여 인증/인가 정책을 환경별로 다르게 적용. */
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity

--- a/src/main/resources/application-qa.yml
+++ b/src/main/resources/application-qa.yml
@@ -99,3 +99,7 @@ sentry:
   # Add data like request headers and IP for users,
   # see https://docs.sentry.io/platforms/java/guides/spring-boot/data-management/data-collected/ for more info
   send-default-pii: true
+
+app:
+  oauth2:
+    authorized-redirect-uri: ${PULLIT_OAUTH2_REDIRECT_URI:https://pull.it.kr/login-success}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -151,7 +151,7 @@ management:
 
 cors:
   allowed-origins:
-    - ${ACCESS_CONTROL_ALLOWED_ORIGINS:https://localhost:5173, https://local.pull.it.kr:5173, https://pull.it.kr, https://www.pull.it.kr}
+    - ${ACCESS_CONTROL_ALLOWED_ORIGINS:https://localhost:5173, https://pull.it.kr, https://www.pull.it.kr}
   # CORS 캐시 시간 (초 단위) - 개발: 5분, 운영: 1시간
   max-age-seconds: ${CORS_MAX_AGE_SECONDS:300}
 
@@ -168,6 +168,8 @@ app:
       base-path: learning-sources
   notification:
     sse-cache-size: 10000
+  oauth2:
+    authorized-redirect-uri: ${PULLIT_OAUTH2_REDIRECT_URI:https://localhost:5173/login-success}
 
 # OpenAPI/Swagger 설정
 springdoc:


### PR DESCRIPTION
<!-- PR 제목을 `이슈번호: 작업내용(명확히)`로 작성해주세요. -->

## PR 설명

카카오로 리다이렉트하는 무한루프 로직 수정
프론트에서 정책적으로 사용하는 /login-success 경로 사용. 그곳으로 리다이렉트

<!--Release Notes:

- N/A _or_ Added/Fixed/Improved ...-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth2 error handling with clearer error redirects on authentication failure

* **Security**
  * Updated public endpoint access list (added common public routes; removed legacy OAuth authorize path)
  * Tightened CORS origins to reduce exposure

* **Configuration**
  * Added configurable OAuth2 redirect URI for deployment-specific redirect behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->