### PR TITLE
btsk-110: 문제 생성 부분에 큐 도입하여 out of memory 문제 해결 및 rabbitmq 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,6 +115,7 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'
     implementation 'org.apache.commons:commons-lang3:3.18.0'
+    implementation 'org.springframework.boot:spring-boot-starter-amqp'
 
     implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -55,6 +55,20 @@ services:
       retries: 5
       start_period: 30s
 
+  rabbitmq:
+    image: 'rabbitmq:3-management-alpine'
+    container_name: pullit-local-rabbitmq
+    ports:
+      - "127.0.0.1:5672:5672"  # AMQP port
+      - "127.0.0.1:15672:15672" # Management UI port
+    networks:
+      - pullit-qa-network
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "ping"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+
 networks:
   pullit-qa-network:
 

--- a/docker-compose.qa.yml
+++ b/docker-compose.qa.yml
@@ -29,10 +29,19 @@ services:
       # Redis 연결 설정
       - REDIS_HOST=pullit-qa-redis
       - REDIS_PORT=6379
+      # RabbitMQ 연결 설정
+      - RABBITMQ_HOST=pullit-qa-rabbitmq
+    spring:
+      rabbitmq:
+        listener:
+          simple:
+            concurrency: 2 # 워커 수를 2로 고정하여 순차 처리
     depends_on:
       pullit-qa-db:
         condition: service_healthy
       pullit-qa-redis:
+        condition: service_started
+      pullit-qa-rabbitmq:
         condition: service_started
     networks:
       - pullit-qa-network
@@ -75,6 +84,23 @@ services:
       - --slow_query_log=1
       - --log_output=TABLE
       - --long_query_time=1
+
+  # QA용 RabbitMQ 메시지 큐
+  pullit-qa-rabbitmq:
+    image: rabbitmq:3-management-alpine
+    container_name: pullit-qa-rabbitmq
+    restart: unless-stopped
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    networks:
+      - pullit-qa-network
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
 
   prometheus:
     container_name: prometheus

--- a/docker-compose.qa.yml
+++ b/docker-compose.qa.yml
@@ -31,11 +31,7 @@ services:
       - REDIS_PORT=6379
       # RabbitMQ 연결 설정
       - RABBITMQ_HOST=pullit-qa-rabbitmq
-    spring:
-      rabbitmq:
-        listener:
-          simple:
-            concurrency: 2 # 워커 수를 2로 고정하여 순차 처리
+      - SPRING_RABBITMQ_LISTENER_SIMPLE_CONCURRENCY=2 # 워커 수를 2로 고정하여 순차 처리
     depends_on:
       pullit-qa-db:
         condition: service_healthy

--- a/src/main/java/kr/it/pullit/modules/learningsource/source/api/SourcePublicApi.java
+++ b/src/main/java/kr/it/pullit/modules/learningsource/source/api/SourcePublicApi.java
@@ -1,6 +1,7 @@
 package kr.it.pullit.modules.learningsource.source.api;
 
 import java.io.InputStream;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import kr.it.pullit.modules.learningsource.source.domain.entity.Source;
@@ -18,6 +19,8 @@ public interface SourcePublicApi {
   List<SourceResponse> getMySources(Long memberId);
 
   InputStream getContentStream(Long sourceId, Long memberId);
+
+  Path downloadFileToTemp(long sourceId, long memberId);
 
   Optional<Source> findById(Long id);
 

--- a/src/main/java/kr/it/pullit/modules/learningsource/source/api/SourcePublicApi.java
+++ b/src/main/java/kr/it/pullit/modules/learningsource/source/api/SourcePublicApi.java
@@ -1,5 +1,6 @@
 package kr.it.pullit.modules.learningsource.source.api;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.List;
@@ -20,7 +21,7 @@ public interface SourcePublicApi {
 
   InputStream getContentStream(Long sourceId, Long memberId);
 
-  Path downloadFileToTemp(long sourceId, long memberId);
+  Path downloadFileToTemp(long sourceId, long memberId) throws IOException;
 
   Optional<Source> findById(Long id);
 

--- a/src/main/java/kr/it/pullit/modules/learningsource/source/service/SourceService.java
+++ b/src/main/java/kr/it/pullit/modules/learningsource/source/service/SourceService.java
@@ -5,6 +5,9 @@ import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import kr.it.pullit.modules.learningsource.source.api.SourcePublicApi;
 import kr.it.pullit.modules.learningsource.source.constant.SourceStatus;
 import kr.it.pullit.modules.learningsource.source.domain.entity.Source;
@@ -22,9 +25,6 @@ import kr.it.pullit.platform.storage.api.S3PublicApi;
 import kr.it.pullit.platform.storage.s3.dto.PresignedUrlResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/kr/it/pullit/modules/learningsource/source/service/SourceService.java
+++ b/src/main/java/kr/it/pullit/modules/learningsource/source/service/SourceService.java
@@ -1,8 +1,12 @@
 package kr.it.pullit.modules.learningsource.source.service;
 
 import java.io.InputStream;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import kr.it.pullit.modules.learningsource.source.api.SourcePublicApi;
 import kr.it.pullit.modules.learningsource.source.constant.SourceStatus;
 import kr.it.pullit.modules.learningsource.source.domain.entity.Source;
@@ -20,9 +24,6 @@ import kr.it.pullit.platform.storage.api.S3PublicApi;
 import kr.it.pullit.platform.storage.s3.dto.PresignedUrlResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -104,6 +105,16 @@ public class SourceService implements SourcePublicApi {
             .orElseThrow(() -> SourceNotFoundException.byId(sourceId));
 
     return s3PublicApi.downloadFileAsStream(source.getFilePath());
+  }
+
+  @Override
+  public Path downloadFileToTemp(long sourceId, long memberId) {
+    Source source =
+        sourceRepository
+            .findByIdAndMemberId(sourceId, memberId)
+            .orElseThrow(() -> SourceNotFoundException.byId(sourceId));
+
+    return s3PublicApi.downloadFileToTemp(source.getFilePath());
   }
 
   @Override

--- a/src/main/java/kr/it/pullit/modules/learningsource/source/service/SourceService.java
+++ b/src/main/java/kr/it/pullit/modules/learningsource/source/service/SourceService.java
@@ -5,9 +5,6 @@ import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import kr.it.pullit.modules.learningsource.source.api.SourcePublicApi;
 import kr.it.pullit.modules.learningsource.source.constant.SourceStatus;
 import kr.it.pullit.modules.learningsource.source.domain.entity.Source;
@@ -25,6 +22,9 @@ import kr.it.pullit.platform.storage.api.S3PublicApi;
 import kr.it.pullit.platform.storage.s3.dto.PresignedUrlResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/kr/it/pullit/modules/learningsource/source/service/SourceService.java
+++ b/src/main/java/kr/it/pullit/modules/learningsource/source/service/SourceService.java
@@ -4,9 +4,6 @@ import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import kr.it.pullit.modules.learningsource.source.api.SourcePublicApi;
 import kr.it.pullit.modules.learningsource.source.constant.SourceStatus;
 import kr.it.pullit.modules.learningsource.source.domain.entity.Source;
@@ -24,6 +21,9 @@ import kr.it.pullit.platform.storage.api.S3PublicApi;
 import kr.it.pullit.platform.storage.s3.dto.PresignedUrlResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/kr/it/pullit/modules/learningsource/source/service/SourceService.java
+++ b/src/main/java/kr/it/pullit/modules/learningsource/source/service/SourceService.java
@@ -1,5 +1,6 @@
 package kr.it.pullit.modules.learningsource.source.service;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.List;
@@ -108,7 +109,7 @@ public class SourceService implements SourcePublicApi {
   }
 
   @Override
-  public Path downloadFileToTemp(long sourceId, long memberId) {
+  public Path downloadFileToTemp(long sourceId, long memberId) throws IOException {
     Source source =
         sourceRepository
             .findByIdAndMemberId(sourceId, memberId)

--- a/src/main/java/kr/it/pullit/modules/questionset/client/dto/request/GeminiRequest.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/client/dto/request/GeminiRequest.java
@@ -1,14 +1,14 @@
 package kr.it.pullit.modules.questionset.client.dto.request;
 
+import com.google.genai.types.Content;
+import com.google.genai.types.GenerateContentConfig;
+import com.google.genai.types.Part;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import com.google.genai.types.Content;
-import com.google.genai.types.GenerateContentConfig;
-import com.google.genai.types.Part;
 import kr.it.pullit.modules.questionset.client.GeminiConfigBuilder;
 import kr.it.pullit.modules.questionset.client.exception.LlmException;
 import kr.it.pullit.modules.questionset.enums.QuestionType;

--- a/src/main/java/kr/it/pullit/modules/questionset/client/dto/request/GeminiRequest.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/client/dto/request/GeminiRequest.java
@@ -1,13 +1,14 @@
 package kr.it.pullit.modules.questionset.client.dto.request;
 
-import com.google.genai.types.Content;
-import com.google.genai.types.GenerateContentConfig;
-import com.google.genai.types.Part;
 import java.io.IOException;
-import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import com.google.genai.types.Content;
+import com.google.genai.types.GenerateContentConfig;
+import com.google.genai.types.Part;
 import kr.it.pullit.modules.questionset.client.GeminiConfigBuilder;
 import kr.it.pullit.modules.questionset.client.exception.LlmException;
 import kr.it.pullit.modules.questionset.enums.QuestionType;
@@ -40,17 +41,17 @@ public record GeminiRequest(String model, Content content, GenerateContentConfig
   }
 
   private static Content buildContent(LlmGeneratedQuestionRequest request) {
-    List<Part> parts = convertInputStreamsToParts(request.fileDataList());
+    List<Part> parts = convertPathsToParts(request.fileDataList());
     parts.add(Part.fromText(request.prompt()));
     return Content.fromParts(parts.toArray(new Part[0]));
   }
 
-  private static List<Part> convertInputStreamsToParts(List<InputStream> fileDataList) {
+  private static List<Part> convertPathsToParts(List<Path> fileDataList) {
     List<Part> parts = new ArrayList<>();
     // TODO: 여러 파일 및 다양한 MIME 타입 지원
-    for (InputStream fileData : fileDataList) {
+    for (Path fileData : fileDataList) {
       try {
-        parts.add(Part.fromBytes(fileData.readAllBytes(), "application/pdf"));
+        parts.add(Part.fromBytes(Files.readAllBytes(fileData), "application/pdf"));
       } catch (IOException e) {
         throw LlmException.withCause(e);
       }

--- a/src/main/java/kr/it/pullit/modules/questionset/client/dto/request/LlmGeneratedQuestionRequest.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/client/dto/request/LlmGeneratedQuestionRequest.java
@@ -1,11 +1,11 @@
 package kr.it.pullit.modules.questionset.client.dto.request;
 
-import java.io.InputStream;
+import java.nio.file.Path;
 import java.util.List;
 import kr.it.pullit.modules.questionset.domain.entity.QuestionGenerationSpecification;
 
 public record LlmGeneratedQuestionRequest(
     String prompt,
-    List<InputStream> fileDataList,
+    List<Path> fileDataList,
     String model,
     QuestionGenerationSpecification specification) {}

--- a/src/main/java/kr/it/pullit/modules/questionset/event/QuestionGenerationEventHandler.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/event/QuestionGenerationEventHandler.java
@@ -1,6 +1,11 @@
 package kr.it.pullit.modules.questionset.event;
 
 import java.util.List;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 import kr.it.pullit.modules.notification.api.NotificationEventPublicApi;
 import kr.it.pullit.modules.projection.learnstats.api.LearnStatsRecalibrationPublicApi;
 import kr.it.pullit.modules.questionset.api.QuestionPublicApi;
@@ -16,18 +21,16 @@ import kr.it.pullit.modules.questionset.service.creationstrategy.QuestionCreatio
 import kr.it.pullit.modules.questionset.web.dto.request.QuestionSetUpdateRequestDto;
 import kr.it.pullit.modules.questionset.web.dto.response.QuestionSetCreationCompleteResponse;
 import kr.it.pullit.modules.questionset.web.dto.response.QuestionSetResponse;
+import kr.it.pullit.platform.mq.RabbitMQConfig;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Async;
-import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class QuestionGenerationEventHandler {
 
+  private final RabbitTemplate rabbitTemplate;
   private final QuestionPublicApi questionPublicApi;
   private final QuestionSetPublicApi questionSetPublicApi;
   private final NotificationEventPublicApi notificationEventPublicApi;
@@ -38,13 +41,17 @@ public class QuestionGenerationEventHandler {
   @Async("applicationTaskExecutor")
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
   public void handleQuestionSetCreatedEvent(QuestionSetCreatedEvent event) {
-    log.info("AI 문제 생성을 시작합니다. QuestionSet ID: {}", event.questionSetId());
+    log.info("QuestionSet ID: {} 에 대한 AI 문제 생성 요청을 메시지 큐에 발행합니다.", event.questionSetId());
 
     try {
-      processQuestionGeneration(event);
-      handleSuccess(event);
+      rabbitTemplate.convertAndSend(
+          RabbitMQConfig.EXCHANGE_NAME, RabbitMQConfig.ROUTING_KEY, event);
     } catch (Exception e) {
-      handleFailure(event, e);
+      log.error(
+          "문제 생성 요청 메시지 발행에 실패했습니다. QuestionSet ID: {}",
+          event.questionSetId(),
+          e);
+      questionSetPublicApi.markAsFailed(event.questionSetId());
     }
   }
 

--- a/src/main/java/kr/it/pullit/modules/questionset/event/QuestionGenerationEventHandler.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/event/QuestionGenerationEventHandler.java
@@ -1,11 +1,6 @@
 package kr.it.pullit.modules.questionset.event;
 
 import java.util.List;
-import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.scheduling.annotation.Async;
-import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 import kr.it.pullit.modules.notification.api.NotificationEventPublicApi;
 import kr.it.pullit.modules.projection.learnstats.api.LearnStatsRecalibrationPublicApi;
 import kr.it.pullit.modules.questionset.api.QuestionPublicApi;
@@ -21,9 +16,14 @@ import kr.it.pullit.modules.questionset.service.creationstrategy.QuestionCreatio
 import kr.it.pullit.modules.questionset.web.dto.request.QuestionSetUpdateRequestDto;
 import kr.it.pullit.modules.questionset.web.dto.response.QuestionSetCreationCompleteResponse;
 import kr.it.pullit.modules.questionset.web.dto.response.QuestionSetResponse;
-import kr.it.pullit.platform.mq.RabbitMQConfig;
+import kr.it.pullit.platform.config.RabbitMqConfig;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @Slf4j
 @Component
@@ -45,12 +45,9 @@ public class QuestionGenerationEventHandler {
 
     try {
       rabbitTemplate.convertAndSend(
-          RabbitMQConfig.EXCHANGE_NAME, RabbitMQConfig.ROUTING_KEY, event);
+          RabbitMqConfig.EXCHANGE_NAME, RabbitMqConfig.ROUTING_KEY, event);
     } catch (Exception e) {
-      log.error(
-          "문제 생성 요청 메시지 발행에 실패했습니다. QuestionSet ID: {}",
-          event.questionSetId(),
-          e);
+      log.error("문제 생성 요청 메시지 발행에 실패했습니다. QuestionSet ID: {}", event.questionSetId(), e);
       questionSetPublicApi.markAsFailed(event.questionSetId());
     }
   }

--- a/src/main/java/kr/it/pullit/modules/questionset/event/QuestionGenerationWorker.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/event/QuestionGenerationWorker.java
@@ -1,8 +1,6 @@
 package kr.it.pullit.modules.questionset.event;
 
 import java.util.List;
-import org.springframework.amqp.rabbit.annotation.RabbitListener;
-import org.springframework.stereotype.Component;
 import kr.it.pullit.modules.notification.api.NotificationEventPublicApi;
 import kr.it.pullit.modules.projection.learnstats.api.LearnStatsRecalibrationPublicApi;
 import kr.it.pullit.modules.questionset.api.QuestionPublicApi;
@@ -18,121 +16,121 @@ import kr.it.pullit.modules.questionset.service.creationstrategy.QuestionCreatio
 import kr.it.pullit.modules.questionset.web.dto.request.QuestionSetUpdateRequestDto;
 import kr.it.pullit.modules.questionset.web.dto.response.QuestionSetCreationCompleteResponse;
 import kr.it.pullit.modules.questionset.web.dto.response.QuestionSetResponse;
-import kr.it.pullit.platform.mq.RabbitMQConfig;
+import kr.it.pullit.platform.config.RabbitMqConfig;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class QuestionGenerationWorker {
 
-    private final QuestionPublicApi questionPublicApi;
-    private final QuestionSetPublicApi questionSetPublicApi;
-    private final NotificationEventPublicApi notificationEventPublicApi;
-    private final SourceValidator sourceValidator;
-    private final QuestionCreationStrategyFactory questionCreationStrategyFactory;
-    private final LearnStatsRecalibrationPublicApi learnStatsRecalibrationPublicApi;
+  private final QuestionPublicApi questionPublicApi;
+  private final QuestionSetPublicApi questionSetPublicApi;
+  private final NotificationEventPublicApi notificationEventPublicApi;
+  private final SourceValidator sourceValidator;
+  private final QuestionCreationStrategyFactory questionCreationStrategyFactory;
+  private final LearnStatsRecalibrationPublicApi learnStatsRecalibrationPublicApi;
 
-    @RabbitListener(queues = RabbitMQConfig.QUEUE_NAME)
-    public void handleQuestionGenerationRequest(QuestionSetCreatedEvent event) {
-        log.info("AI 문제 생성을 시작합니다. QuestionSet ID: {}", event.questionSetId());
+  @RabbitListener(queues = RabbitMqConfig.QUEUE_NAME)
+  public void handleQuestionGenerationRequest(QuestionSetCreatedEvent event) {
+    log.info("AI 문제 생성을 시작합니다. QuestionSet ID: {}", event.questionSetId());
 
-        try {
-            processQuestionGeneration(event);
-            handleSuccess(event);
-        } catch (Exception e) {
-            handleFailure(event, e);
-        }
+    try {
+      processQuestionGeneration(event);
+      handleSuccess(event);
+    } catch (Exception e) {
+      handleFailure(event, e);
     }
+  }
 
-    private void processQuestionGeneration(QuestionSetCreatedEvent event) {
-        QuestionGenerationRequest request = createGenerationRequest(event);
-        LlmGeneratedQuestionSetResponse response = questionPublicApi.generateQuestions(request);
+  private void processQuestionGeneration(QuestionSetCreatedEvent event) {
+    QuestionGenerationRequest request = createGenerationRequest(event);
+    LlmGeneratedQuestionSetResponse response = questionPublicApi.generateQuestions(request);
 
-        questionSetPublicApi.update(
-            event.questionSetId(), toQuestionSetUpdateRequestDto(response), event.ownerId());
-        saveQuestions(event.questionSetId(), event.ownerId(), response.questions());
+    questionSetPublicApi.update(
+        event.questionSetId(), toQuestionSetUpdateRequestDto(response), event.ownerId());
+    saveQuestions(event.questionSetId(), event.ownerId(), response.questions());
 
-        questionSetPublicApi.markAsComplete(event.questionSetId());
-    }
+    questionSetPublicApi.markAsComplete(event.questionSetId());
+  }
 
-    private static QuestionSetUpdateRequestDto toQuestionSetUpdateRequestDto(
-        LlmGeneratedQuestionSetResponse response) {
-        return QuestionSetUpdateRequestDto.builder().title(response.title()).build();
-    }
+  private static QuestionSetUpdateRequestDto toQuestionSetUpdateRequestDto(
+      LlmGeneratedQuestionSetResponse response) {
+    return QuestionSetUpdateRequestDto.builder().title(response.title()).build();
+  }
 
-    private QuestionGenerationRequest createGenerationRequest(QuestionSetCreatedEvent event) {
-        QuestionSetResponse questionSetResponse =
-            fetchQuestionSetMetadata(event.questionSetId(), event.ownerId());
+  private QuestionGenerationRequest createGenerationRequest(QuestionSetCreatedEvent event) {
+    QuestionSetResponse questionSetResponse =
+        fetchQuestionSetMetadata(event.questionSetId(), event.ownerId());
 
-        sourceValidator.validateSourcesAreReady(
-            questionSetResponse.getSourceIds(), event.questionSetId());
+    sourceValidator.validateSourcesAreReady(
+        questionSetResponse.getSourceIds(), event.questionSetId());
 
-        QuestionGenerationSpecification specification = createSpecificationFrom(questionSetResponse);
-        return new QuestionGenerationRequest(
-            event.ownerId(), event.questionSetId(), questionSetResponse.getSourceIds(), specification);
-    }
+    QuestionGenerationSpecification specification = createSpecificationFrom(questionSetResponse);
+    return new QuestionGenerationRequest(
+        event.ownerId(), event.questionSetId(), questionSetResponse.getSourceIds(), specification);
+  }
 
-    private QuestionSetResponse fetchQuestionSetMetadata(Long questionSetId, Long ownerId) {
-        return questionSetPublicApi.getQuestionSetWhenHaveNoQuestionsYet(questionSetId, ownerId);
-    }
+  private QuestionSetResponse fetchQuestionSetMetadata(Long questionSetId, Long ownerId) {
+    return questionSetPublicApi.getQuestionSetWhenHaveNoQuestionsYet(questionSetId, ownerId);
+  }
 
-    private QuestionGenerationSpecification createSpecificationFrom(
-        QuestionSetResponse questionSetResponse) {
-        return new QuestionGenerationSpecification(
-            questionSetResponse.getDifficulty(),
-            questionSetResponse.getType(),
-            questionSetResponse.getQuestionLength());
-    }
+  private QuestionGenerationSpecification createSpecificationFrom(
+      QuestionSetResponse questionSetResponse) {
+    return new QuestionGenerationSpecification(
+        questionSetResponse.getDifficulty(),
+        questionSetResponse.getType(),
+        questionSetResponse.getQuestionLength());
+  }
 
-    private void saveQuestions(
-        Long questionSetId, Long memberId, List<LlmGeneratedQuestionResponse> questionDtos) {
-        QuestionSet questionSet = findQuestionSetById(questionSetId, memberId);
-        questionDtos.forEach(dto -> saveSingleQuestion(questionSet, dto));
-    }
+  private void saveQuestions(
+      Long questionSetId, Long memberId, List<LlmGeneratedQuestionResponse> questionDtos) {
+    QuestionSet questionSet = findQuestionSetById(questionSetId, memberId);
+    questionDtos.forEach(dto -> saveSingleQuestion(questionSet, dto));
+  }
 
-    private void saveSingleQuestion(
-        QuestionSet questionSet, LlmGeneratedQuestionResponse questionDto) {
-        log.info("Generated Question: {}", questionDto.questionText());
-        Question question = createQuestion(questionSet, questionDto);
-        questionPublicApi.saveQuestion(question);
-    }
+  private void saveSingleQuestion(
+      QuestionSet questionSet, LlmGeneratedQuestionResponse questionDto) {
+    log.info("Generated Question: {}", questionDto.questionText());
+    Question question = createQuestion(questionSet, questionDto);
+    questionPublicApi.saveQuestion(question);
+  }
 
-    private QuestionSet findQuestionSetById(Long questionSetId, Long memberId) {
-        return questionSetPublicApi
-            .findEntityByIdAndMemberId(questionSetId, memberId)
-            .orElseThrow(
-                () -> new IllegalArgumentException("QuestionSet not found with id: " + questionSetId));
-    }
+  private QuestionSet findQuestionSetById(Long questionSetId, Long memberId) {
+    return questionSetPublicApi
+        .findEntityByIdAndMemberId(questionSetId, memberId)
+        .orElseThrow(
+            () -> new IllegalArgumentException("QuestionSet not found with id: " + questionSetId));
+  }
 
+  private Question createQuestion(
+      QuestionSet questionSet, LlmGeneratedQuestionResponse questionDto) {
 
+    return questionCreationStrategyFactory
+        .getStrategy(questionSet.getType())
+        .create(questionSet, questionDto);
+  }
 
-    private Question createQuestion(
-        QuestionSet questionSet, LlmGeneratedQuestionResponse questionDto) {
+  private void handleSuccess(QuestionSetCreatedEvent event) {
+    QuestionSetCreationCompleteResponse responseDto = createSuccessResponse(event);
+    notificationEventPublicApi.publishQuestionSetCreationComplete(event.ownerId(), responseDto);
+    learnStatsRecalibrationPublicApi.recalibrateTotalQuestionCountForMember(event.ownerId());
+    log.info("AI 문제 생성이 완료되었습니다. QuestionSet ID: {}", event.questionSetId());
+  }
 
-        return questionCreationStrategyFactory
-            .getStrategy(questionSet.getType())
-            .create(questionSet, questionDto);
-    }
+  private QuestionSetCreationCompleteResponse createSuccessResponse(QuestionSetCreatedEvent event) {
+    QuestionSetResponse questionSetResponse =
+        questionSetPublicApi.getQuestionSetForSolving(
+            event.questionSetId(), event.ownerId(), false);
+    return new QuestionSetCreationCompleteResponse(
+        true, questionSetResponse.getId(), "문제집 생성 완료 (" + questionSetResponse.getTitle() + ")");
+  }
 
-    private void handleSuccess(QuestionSetCreatedEvent event) {
-        QuestionSetCreationCompleteResponse responseDto = createSuccessResponse(event);
-        notificationEventPublicApi.publishQuestionSetCreationComplete(event.ownerId(), responseDto);
-        learnStatsRecalibrationPublicApi.recalibrateTotalQuestionCountForMember(event.ownerId());
-        log.info("AI 문제 생성이 완료되었습니다. QuestionSet ID: {}", event.questionSetId());
-    }
-
-    private QuestionSetCreationCompleteResponse createSuccessResponse(QuestionSetCreatedEvent event) {
-        QuestionSetResponse questionSetResponse =
-            questionSetPublicApi.getQuestionSetForSolving(
-                event.questionSetId(), event.ownerId(), false);
-        return new QuestionSetCreationCompleteResponse(
-            true, questionSetResponse.getId(), "문제집 생성 완료 (" + questionSetResponse.getTitle() + ")");
-    }
-
-    private void handleFailure(QuestionSetCreatedEvent event, Exception e) {
-        log.error("문제 생성 중 오류 발생. QuestionSet ID: {}", event.questionSetId(), e);
-        questionSetPublicApi.markAsFailed(event.questionSetId());
-    }
+  private void handleFailure(QuestionSetCreatedEvent event, Exception e) {
+    log.error("문제 생성 중 오류 발생. QuestionSet ID: {}", event.questionSetId(), e);
+    questionSetPublicApi.markAsFailed(event.questionSetId());
+  }
 }

--- a/src/main/java/kr/it/pullit/modules/questionset/event/QuestionGenerationWorker.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/event/QuestionGenerationWorker.java
@@ -1,0 +1,138 @@
+package kr.it.pullit.modules.questionset.event;
+
+import java.util.List;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+import kr.it.pullit.modules.notification.api.NotificationEventPublicApi;
+import kr.it.pullit.modules.projection.learnstats.api.LearnStatsRecalibrationPublicApi;
+import kr.it.pullit.modules.questionset.api.QuestionPublicApi;
+import kr.it.pullit.modules.questionset.api.QuestionSetPublicApi;
+import kr.it.pullit.modules.questionset.client.dto.response.LlmGeneratedQuestionResponse;
+import kr.it.pullit.modules.questionset.client.dto.response.LlmGeneratedQuestionSetResponse;
+import kr.it.pullit.modules.questionset.domain.entity.Question;
+import kr.it.pullit.modules.questionset.domain.entity.QuestionGenerationRequest;
+import kr.it.pullit.modules.questionset.domain.entity.QuestionGenerationSpecification;
+import kr.it.pullit.modules.questionset.domain.entity.QuestionSet;
+import kr.it.pullit.modules.questionset.service.SourceValidator;
+import kr.it.pullit.modules.questionset.service.creationstrategy.QuestionCreationStrategyFactory;
+import kr.it.pullit.modules.questionset.web.dto.request.QuestionSetUpdateRequestDto;
+import kr.it.pullit.modules.questionset.web.dto.response.QuestionSetCreationCompleteResponse;
+import kr.it.pullit.modules.questionset.web.dto.response.QuestionSetResponse;
+import kr.it.pullit.platform.mq.RabbitMQConfig;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class QuestionGenerationWorker {
+
+    private final QuestionPublicApi questionPublicApi;
+    private final QuestionSetPublicApi questionSetPublicApi;
+    private final NotificationEventPublicApi notificationEventPublicApi;
+    private final SourceValidator sourceValidator;
+    private final QuestionCreationStrategyFactory questionCreationStrategyFactory;
+    private final LearnStatsRecalibrationPublicApi learnStatsRecalibrationPublicApi;
+
+    @RabbitListener(queues = RabbitMQConfig.QUEUE_NAME)
+    public void handleQuestionGenerationRequest(QuestionSetCreatedEvent event) {
+        log.info("AI 문제 생성을 시작합니다. QuestionSet ID: {}", event.questionSetId());
+
+        try {
+            processQuestionGeneration(event);
+            handleSuccess(event);
+        } catch (Exception e) {
+            handleFailure(event, e);
+        }
+    }
+
+    private void processQuestionGeneration(QuestionSetCreatedEvent event) {
+        QuestionGenerationRequest request = createGenerationRequest(event);
+        LlmGeneratedQuestionSetResponse response = questionPublicApi.generateQuestions(request);
+
+        questionSetPublicApi.update(
+            event.questionSetId(), toQuestionSetUpdateRequestDto(response), event.ownerId());
+        saveQuestions(event.questionSetId(), event.ownerId(), response.questions());
+
+        questionSetPublicApi.markAsComplete(event.questionSetId());
+    }
+
+    private static QuestionSetUpdateRequestDto toQuestionSetUpdateRequestDto(
+        LlmGeneratedQuestionSetResponse response) {
+        return QuestionSetUpdateRequestDto.builder().title(response.title()).build();
+    }
+
+    private QuestionGenerationRequest createGenerationRequest(QuestionSetCreatedEvent event) {
+        QuestionSetResponse questionSetResponse =
+            fetchQuestionSetMetadata(event.questionSetId(), event.ownerId());
+
+        sourceValidator.validateSourcesAreReady(
+            questionSetResponse.getSourceIds(), event.questionSetId());
+
+        QuestionGenerationSpecification specification = createSpecificationFrom(questionSetResponse);
+        return new QuestionGenerationRequest(
+            event.ownerId(), event.questionSetId(), questionSetResponse.getSourceIds(), specification);
+    }
+
+    private QuestionSetResponse fetchQuestionSetMetadata(Long questionSetId, Long ownerId) {
+        return questionSetPublicApi.getQuestionSetWhenHaveNoQuestionsYet(questionSetId, ownerId);
+    }
+
+    private QuestionGenerationSpecification createSpecificationFrom(
+        QuestionSetResponse questionSetResponse) {
+        return new QuestionGenerationSpecification(
+            questionSetResponse.getDifficulty(),
+            questionSetResponse.getType(),
+            questionSetResponse.getQuestionLength());
+    }
+
+    private void saveQuestions(
+        Long questionSetId, Long memberId, List<LlmGeneratedQuestionResponse> questionDtos) {
+        QuestionSet questionSet = findQuestionSetById(questionSetId, memberId);
+        questionDtos.forEach(dto -> saveSingleQuestion(questionSet, dto));
+    }
+
+    private void saveSingleQuestion(
+        QuestionSet questionSet, LlmGeneratedQuestionResponse questionDto) {
+        log.info("Generated Question: {}", questionDto.questionText());
+        Question question = createQuestion(questionSet, questionDto);
+        questionPublicApi.saveQuestion(question);
+    }
+
+    private QuestionSet findQuestionSetById(Long questionSetId, Long memberId) {
+        return questionSetPublicApi
+            .findEntityByIdAndMemberId(questionSetId, memberId)
+            .orElseThrow(
+                () -> new IllegalArgumentException("QuestionSet not found with id: " + questionSetId));
+    }
+
+
+
+    private Question createQuestion(
+        QuestionSet questionSet, LlmGeneratedQuestionResponse questionDto) {
+
+        return questionCreationStrategyFactory
+            .getStrategy(questionSet.getType())
+            .create(questionSet, questionDto);
+    }
+
+    private void handleSuccess(QuestionSetCreatedEvent event) {
+        QuestionSetCreationCompleteResponse responseDto = createSuccessResponse(event);
+        notificationEventPublicApi.publishQuestionSetCreationComplete(event.ownerId(), responseDto);
+        learnStatsRecalibrationPublicApi.recalibrateTotalQuestionCountForMember(event.ownerId());
+        log.info("AI 문제 생성이 완료되었습니다. QuestionSet ID: {}", event.questionSetId());
+    }
+
+    private QuestionSetCreationCompleteResponse createSuccessResponse(QuestionSetCreatedEvent event) {
+        QuestionSetResponse questionSetResponse =
+            questionSetPublicApi.getQuestionSetForSolving(
+                event.questionSetId(), event.ownerId(), false);
+        return new QuestionSetCreationCompleteResponse(
+            true, questionSetResponse.getId(), "문제집 생성 완료 (" + questionSetResponse.getTitle() + ")");
+    }
+
+    private void handleFailure(QuestionSetCreatedEvent event, Exception e) {
+        log.error("문제 생성 중 오류 발생. QuestionSet ID: {}", event.questionSetId(), e);
+        questionSetPublicApi.markAsFailed(event.questionSetId());
+    }
+}

--- a/src/main/java/kr/it/pullit/modules/questionset/service/QuestionService.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/service/QuestionService.java
@@ -1,7 +1,9 @@
 package kr.it.pullit.modules.questionset.service;
 
 import jakarta.transaction.Transactional;
+import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import kr.it.pullit.modules.learningsource.source.api.SourcePublicApi;
@@ -47,9 +49,9 @@ public class QuestionService implements QuestionPublicApi {
     validateQuestionSetExists(request.questionSetId(), request.ownerId());
 
     LlmPrompt llmPrompt = createLlmPrompt(request.specification());
-    List<Path> sourceFilePaths = getSourceFilePaths(request.sourceIds(), request.ownerId());
-
+    List<Path> sourceFilePaths = new ArrayList<>();
     try {
+      sourceFilePaths = getSourceFilePaths(request.sourceIds(), request.ownerId());
       return callLlmClient(
           request.questionSetId(), llmPrompt, sourceFilePaths, request.specification());
     } finally {
@@ -118,9 +120,16 @@ public class QuestionService implements QuestionPublicApi {
   }
 
   private List<Path> getSourceFilePaths(List<Long> sourceIds, Long ownerId) {
-    return sourceIds.stream()
-        .map(sourceId -> sourcePublicApi.downloadFileToTemp(sourceId, ownerId))
-        .toList();
+    List<Path> downloadedPaths = new ArrayList<>();
+    try {
+      for (Long sourceId : sourceIds) {
+        downloadedPaths.add(sourcePublicApi.downloadFileToTemp(sourceId, ownerId));
+      }
+      return downloadedPaths;
+    } catch (IOException e) {
+      questionSetFileTempManager.cleanUp(downloadedPaths);
+      throw new RuntimeException("소스파일 다운로드 중 오류가 발생했습니다.", e);
+    }
   }
 
   private LlmGeneratedQuestionSetResponse callLlmClient(

--- a/src/main/java/kr/it/pullit/modules/questionset/service/QuestionService.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/service/QuestionService.java
@@ -1,10 +1,9 @@
 package kr.it.pullit.modules.questionset.service;
 
+import jakarta.transaction.Transactional;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.stereotype.Service;
-import jakarta.transaction.Transactional;
 import kr.it.pullit.modules.learningsource.source.api.SourcePublicApi;
 import kr.it.pullit.modules.questionset.api.LlmClient;
 import kr.it.pullit.modules.questionset.api.QuestionPublicApi;
@@ -28,6 +27,7 @@ import kr.it.pullit.modules.questionset.web.dto.request.QuestionUpdateRequestDto
 import kr.it.pullit.modules.questionset.web.dto.response.QuestionResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j
@@ -47,8 +47,7 @@ public class QuestionService implements QuestionPublicApi {
     validateQuestionSetExists(request.questionSetId(), request.ownerId());
 
     LlmPrompt llmPrompt = createLlmPrompt(request.specification());
-    List<Path> sourceFilePaths =
-        getSourceFilePaths(request.sourceIds(), request.ownerId());
+    List<Path> sourceFilePaths = getSourceFilePaths(request.sourceIds(), request.ownerId());
 
     try {
       return callLlmClient(
@@ -144,8 +143,7 @@ public class QuestionService implements QuestionPublicApi {
       List<Path> sourceFilePaths,
       QuestionGenerationSpecification spec,
       String modelName) {
-    return new LlmGeneratedQuestionRequest(
-        llmPrompt.value(), sourceFilePaths, modelName, spec);
+    return new LlmGeneratedQuestionRequest(llmPrompt.value(), sourceFilePaths, modelName, spec);
   }
 
   private QuestionSet findQuestionSetById(Long questionSetId) {

--- a/src/main/java/kr/it/pullit/modules/questionset/service/QuestionService.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/service/QuestionService.java
@@ -1,12 +1,11 @@
 package kr.it.pullit.modules.questionset.service;
 
+import jakarta.transaction.Transactional;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.stereotype.Service;
-import jakarta.transaction.Transactional;
 import kr.it.pullit.modules.learningsource.source.api.SourcePublicApi;
 import kr.it.pullit.modules.questionset.api.LlmClient;
 import kr.it.pullit.modules.questionset.api.QuestionPublicApi;
@@ -30,6 +29,7 @@ import kr.it.pullit.modules.questionset.web.dto.request.QuestionUpdateRequestDto
 import kr.it.pullit.modules.questionset.web.dto.response.QuestionResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j

--- a/src/main/java/kr/it/pullit/modules/questionset/service/QuestionService.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/service/QuestionService.java
@@ -1,9 +1,10 @@
 package kr.it.pullit.modules.questionset.service;
 
-import jakarta.transaction.Transactional;
-import java.io.InputStream;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.stereotype.Service;
+import jakarta.transaction.Transactional;
 import kr.it.pullit.modules.learningsource.source.api.SourcePublicApi;
 import kr.it.pullit.modules.questionset.api.LlmClient;
 import kr.it.pullit.modules.questionset.api.QuestionPublicApi;
@@ -27,7 +28,6 @@ import kr.it.pullit.modules.questionset.web.dto.request.QuestionUpdateRequestDto
 import kr.it.pullit.modules.questionset.web.dto.response.QuestionResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j
@@ -40,17 +40,22 @@ public class QuestionService implements QuestionPublicApi {
   private final QuestionSetRepository questionSetRepository;
   private final SourcePublicApi sourcePublicApi;
   private final LlmClient llmClient;
+  private final QuestionSetFileTempManager questionSetFileTempManager;
 
   @Override
   public LlmGeneratedQuestionSetResponse generateQuestions(QuestionGenerationRequest request) {
     validateQuestionSetExists(request.questionSetId(), request.ownerId());
 
     LlmPrompt llmPrompt = createLlmPrompt(request.specification());
-    List<InputStream> sourceFileDataStreams =
-        getSourceFileStreams(request.sourceIds(), request.ownerId());
+    List<Path> sourceFilePaths =
+        getSourceFilePaths(request.sourceIds(), request.ownerId());
 
-    return callLlmClient(
-        request.questionSetId(), llmPrompt, sourceFileDataStreams, request.specification());
+    try {
+      return callLlmClient(
+          request.questionSetId(), llmPrompt, sourceFilePaths, request.specification());
+    } finally {
+      questionSetFileTempManager.cleanUp(sourceFilePaths);
+    }
   }
 
   @Override
@@ -113,20 +118,20 @@ public class QuestionService implements QuestionPublicApi {
     return LlmPrompt.compose(spec.difficultyType(), spec.questionType());
   }
 
-  private List<InputStream> getSourceFileStreams(List<Long> sourceIds, Long ownerId) {
+  private List<Path> getSourceFilePaths(List<Long> sourceIds, Long ownerId) {
     return sourceIds.stream()
-        .map(sourceId -> sourcePublicApi.getContentStream(sourceId, ownerId))
+        .map(sourceId -> sourcePublicApi.downloadFileToTemp(sourceId, ownerId))
         .toList();
   }
 
   private LlmGeneratedQuestionSetResponse callLlmClient(
       Long questionSetId,
       LlmPrompt llmPrompt,
-      List<InputStream> sourceFileDataStreams,
+      List<Path> sourceFilePaths,
       QuestionGenerationSpecification spec) {
     logLlmCall(questionSetId, DEFAULT_MODEL_NAME);
     LlmGeneratedQuestionRequest request =
-        createLlmRequest(llmPrompt, sourceFileDataStreams, spec, DEFAULT_MODEL_NAME);
+        createLlmRequest(llmPrompt, sourceFilePaths, spec, DEFAULT_MODEL_NAME);
     return llmClient.getLlmGeneratedQuestionContent(request);
   }
 
@@ -136,11 +141,11 @@ public class QuestionService implements QuestionPublicApi {
 
   private LlmGeneratedQuestionRequest createLlmRequest(
       LlmPrompt llmPrompt,
-      List<InputStream> sourceFileDataStreams,
+      List<Path> sourceFilePaths,
       QuestionGenerationSpecification spec,
       String modelName) {
     return new LlmGeneratedQuestionRequest(
-        llmPrompt.value(), sourceFileDataStreams, modelName, spec);
+        llmPrompt.value(), sourceFilePaths, modelName, spec);
   }
 
   private QuestionSet findQuestionSetById(Long questionSetId) {

--- a/src/main/java/kr/it/pullit/modules/questionset/service/QuestionService.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/service/QuestionService.java
@@ -1,11 +1,12 @@
 package kr.it.pullit.modules.questionset.service;
 
-import jakarta.transaction.Transactional;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.stereotype.Service;
+import jakarta.transaction.Transactional;
 import kr.it.pullit.modules.learningsource.source.api.SourcePublicApi;
 import kr.it.pullit.modules.questionset.api.LlmClient;
 import kr.it.pullit.modules.questionset.api.QuestionPublicApi;
@@ -29,7 +30,6 @@ import kr.it.pullit.modules.questionset.web.dto.request.QuestionUpdateRequestDto
 import kr.it.pullit.modules.questionset.web.dto.response.QuestionResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j

--- a/src/main/java/kr/it/pullit/modules/questionset/service/QuestionSetFileTempManager.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/service/QuestionSetFileTempManager.java
@@ -4,33 +4,33 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import org.springframework.stereotype.Component;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
 public class QuestionSetFileTempManager {
 
-    public void cleanUp(List<Path> paths) {
-        if (paths == null || paths.isEmpty()) {
-            return;
-        }
-
-        log.info("임시 파일 정리를 시작합니다. 대상 파일 {}개", paths.size());
-        for (Path path : paths) {
-            deleteIfExists(path);
-        }
-        log.info("임시 파일 정리를 완료했습니다.");
+  public void cleanUp(List<Path> paths) {
+    if (paths == null || paths.isEmpty()) {
+      return;
     }
 
-    private void deleteIfExists(Path path) {
-        try {
-            if (Files.exists(path)) {
-                Files.delete(path);
-                log.debug("임시 파일을 삭제했습니다: {}", path);
-            }
-        } catch (IOException e) {
-            log.warn("임시 파일 삭제에 실패했습니다: {}", path, e);
-        }
+    log.info("임시 파일 정리를 시작합니다. 대상 파일 {}개", paths.size());
+    for (Path path : paths) {
+      deleteIfExists(path);
     }
+    log.info("임시 파일 정리를 완료했습니다.");
+  }
+
+  private void deleteIfExists(Path path) {
+    try {
+      if (Files.exists(path)) {
+        Files.delete(path);
+        log.debug("임시 파일을 삭제했습니다: {}", path);
+      }
+    } catch (IOException e) {
+      log.warn("임시 파일 삭제에 실패했습니다: {}", path, e);
+    }
+  }
 }

--- a/src/main/java/kr/it/pullit/modules/questionset/service/QuestionSetFileTempManager.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/service/QuestionSetFileTempManager.java
@@ -1,0 +1,36 @@
+package kr.it.pullit.modules.questionset.service;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.springframework.stereotype.Component;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+public class QuestionSetFileTempManager {
+
+    public void cleanUp(List<Path> paths) {
+        if (paths == null || paths.isEmpty()) {
+            return;
+        }
+
+        log.info("임시 파일 정리를 시작합니다. 대상 파일 {}개", paths.size());
+        for (Path path : paths) {
+            deleteIfExists(path);
+        }
+        log.info("임시 파일 정리를 완료했습니다.");
+    }
+
+    private void deleteIfExists(Path path) {
+        try {
+            if (Files.exists(path)) {
+                Files.delete(path);
+                log.debug("임시 파일을 삭제했습니다: {}", path);
+            }
+        } catch (IOException e) {
+            log.warn("임시 파일 삭제에 실패했습니다: {}", path, e);
+        }
+    }
+}

--- a/src/main/java/kr/it/pullit/platform/config/RabbitMqConfig.java
+++ b/src/main/java/kr/it/pullit/platform/config/RabbitMqConfig.java
@@ -1,4 +1,4 @@
-package kr.it.pullit.platform.mq;
+package kr.it.pullit.platform.config;
 
 import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.BindingBuilder;
@@ -12,7 +12,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-public class RabbitMQConfig {
+public class RabbitMqConfig {
 
   public static final String EXCHANGE_NAME = "question.exchange";
   public static final String QUEUE_NAME = "question.generation.queue";
@@ -36,7 +36,8 @@ public class RabbitMQConfig {
   }
 
   @Bean
-  public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory, MessageConverter messageConverter) {
+  public RabbitTemplate rabbitTemplate(
+      ConnectionFactory connectionFactory, MessageConverter messageConverter) {
     RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
     rabbitTemplate.setMessageConverter(messageConverter);
     return rabbitTemplate;

--- a/src/main/java/kr/it/pullit/platform/mq/RabbitMQConfig.java
+++ b/src/main/java/kr/it/pullit/platform/mq/RabbitMQConfig.java
@@ -1,0 +1,49 @@
+package kr.it.pullit.platform.mq;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMQConfig {
+
+  public static final String EXCHANGE_NAME = "question.exchange";
+  public static final String QUEUE_NAME = "question.generation.queue";
+  public static final String ROUTING_KEY = "question.generation.request";
+
+  @Bean
+  public TopicExchange exchange() {
+    return new TopicExchange(EXCHANGE_NAME);
+  }
+
+  // org.springframework.amqp.core.Queue 사용!
+  @Bean
+  public Queue queue() {
+    // durable=true 로 생성 (필요에 맞게 exclusive, autoDelete 조정 가능)
+    return new Queue(QUEUE_NAME, true);
+  }
+
+  @Bean
+  public Binding binding(Queue queue, TopicExchange exchange) {
+    return BindingBuilder.bind(queue).to(exchange).with(ROUTING_KEY);
+  }
+
+  @Bean
+  public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory, MessageConverter messageConverter) {
+    RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
+    rabbitTemplate.setMessageConverter(messageConverter);
+    return rabbitTemplate;
+  }
+
+  @Bean
+  public MessageConverter messageConverter() {
+    return new Jackson2JsonMessageConverter();
+  }
+}

--- a/src/main/java/kr/it/pullit/platform/storage/api/S3PublicApi.java
+++ b/src/main/java/kr/it/pullit/platform/storage/api/S3PublicApi.java
@@ -1,6 +1,7 @@
 package kr.it.pullit.platform.storage.api;
 
 import java.io.InputStream;
+import java.nio.file.Path;
 import kr.it.pullit.platform.storage.s3.dto.PresignedUrlResponse;
 
 public interface S3PublicApi {
@@ -9,6 +10,8 @@ public interface S3PublicApi {
       String fileName, String contentType, Long fileSize, Long ownerId);
 
   InputStream downloadFileAsStream(String filePath);
+
+  Path downloadFileToTemp(String filePath);
 
   boolean fileExists(String filePath);
 

--- a/src/main/java/kr/it/pullit/platform/storage/api/S3PublicApi.java
+++ b/src/main/java/kr/it/pullit/platform/storage/api/S3PublicApi.java
@@ -1,5 +1,6 @@
 package kr.it.pullit.platform.storage.api;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import kr.it.pullit.platform.storage.s3.dto.PresignedUrlResponse;
@@ -11,7 +12,7 @@ public interface S3PublicApi {
 
   InputStream downloadFileAsStream(String filePath);
 
-  Path downloadFileToTemp(String filePath);
+  Path downloadFileToTemp(String filePath) throws IOException;
 
   boolean fileExists(String filePath);
 

--- a/src/main/java/kr/it/pullit/platform/storage/s3/service/S3PresignedUrlService.java
+++ b/src/main/java/kr/it/pullit/platform/storage/s3/service/S3PresignedUrlService.java
@@ -5,6 +5,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import org.springframework.stereotype.Service;
 import kr.it.pullit.platform.storage.api.S3PublicApi;
 import kr.it.pullit.platform.storage.core.FilePathPolicy;
 import kr.it.pullit.platform.storage.core.FileValidation;
@@ -13,7 +14,6 @@ import kr.it.pullit.platform.storage.s3.client.FileStorageClient;
 import kr.it.pullit.platform.storage.s3.dto.PresignedUrlResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
-import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
@@ -49,7 +49,7 @@ public class S3PresignedUrlService implements S3PublicApi {
   @SneakyThrows
   @Override
   public Path downloadFileToTemp(String filePath) {
-    Path tempFile = Files.createTempFile("pullit-source-", ".pdf");
+    Path tempFile = Files.createTempFile("question-generation-", ".pdf");
     try (InputStream inputStream = fileStorageClient.downloadFileAsStream(filePath)) {
       Files.copy(inputStream, tempFile, StandardCopyOption.REPLACE_EXISTING);
     }

--- a/src/main/java/kr/it/pullit/platform/storage/s3/service/S3PresignedUrlService.java
+++ b/src/main/java/kr/it/pullit/platform/storage/s3/service/S3PresignedUrlService.java
@@ -5,7 +5,6 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import org.springframework.stereotype.Service;
 import kr.it.pullit.platform.storage.api.S3PublicApi;
 import kr.it.pullit.platform.storage.core.FilePathPolicy;
 import kr.it.pullit.platform.storage.core.FileValidation;
@@ -14,6 +13,7 @@ import kr.it.pullit.platform.storage.s3.client.FileStorageClient;
 import kr.it.pullit.platform.storage.s3.dto.PresignedUrlResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
+import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/kr/it/pullit/platform/storage/s3/service/S3PresignedUrlService.java
+++ b/src/main/java/kr/it/pullit/platform/storage/s3/service/S3PresignedUrlService.java
@@ -1,5 +1,6 @@
 package kr.it.pullit.platform.storage.s3.service;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Files;
@@ -12,7 +13,6 @@ import kr.it.pullit.platform.storage.core.S3StorageProps;
 import kr.it.pullit.platform.storage.s3.client.FileStorageClient;
 import kr.it.pullit.platform.storage.s3.dto.PresignedUrlResponse;
 import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -46,9 +46,16 @@ public class S3PresignedUrlService implements S3PublicApi {
     return fileStorageClient.downloadFileAsStream(filePath);
   }
 
-  @SneakyThrows
+  /**
+   * S3의 파일을 디스크의 임시 파일로 다운로드합니다. 디스크 공간 고갈을 방지하기 위해, 이 메서드를 호출한 측에서는 반환된 임시 파일을 반드시 사용 후 삭제해야 합니다.
+   * Files.delete(path) 또는 Files.deleteIfExists(path)를 사용하세요.
+   *
+   * @param filePath 다운로드할 S3 파일 경로
+   * @return 다운로드된 콘텐츠를 포함하는 임시 파일의 Path
+   * @throws IOException 다운로드 또는 파일 생성 실패 시 발생
+   */
   @Override
-  public Path downloadFileToTemp(String filePath) {
+  public Path downloadFileToTemp(String filePath) throws IOException {
     Path tempFile = Files.createTempFile("question-generation-", ".pdf");
     try (InputStream inputStream = fileStorageClient.downloadFileAsStream(filePath)) {
       Files.copy(inputStream, tempFile, StandardCopyOption.REPLACE_EXISTING);

--- a/src/main/java/kr/it/pullit/platform/storage/s3/service/S3PresignedUrlService.java
+++ b/src/main/java/kr/it/pullit/platform/storage/s3/service/S3PresignedUrlService.java
@@ -2,6 +2,10 @@ package kr.it.pullit.platform.storage.s3.service;
 
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import org.springframework.stereotype.Service;
 import kr.it.pullit.platform.storage.api.S3PublicApi;
 import kr.it.pullit.platform.storage.core.FilePathPolicy;
 import kr.it.pullit.platform.storage.core.FileValidation;
@@ -9,7 +13,7 @@ import kr.it.pullit.platform.storage.core.S3StorageProps;
 import kr.it.pullit.platform.storage.s3.client.FileStorageClient;
 import kr.it.pullit.platform.storage.s3.dto.PresignedUrlResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
+import lombok.SneakyThrows;
 
 @Service
 @RequiredArgsConstructor
@@ -40,6 +44,16 @@ public class S3PresignedUrlService implements S3PublicApi {
   @Override
   public InputStream downloadFileAsStream(String filePath) {
     return fileStorageClient.downloadFileAsStream(filePath);
+  }
+
+  @SneakyThrows
+  @Override
+  public Path downloadFileToTemp(String filePath) {
+    Path tempFile = Files.createTempFile("pullit-source-", ".pdf");
+    try (InputStream inputStream = fileStorageClient.downloadFileAsStream(filePath)) {
+      Files.copy(inputStream, tempFile, StandardCopyOption.REPLACE_EXISTING);
+    }
+    return tempFile;
   }
 
   @Override

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,9 @@ spring:
     username: myuser
     password: secret
 
+  rabbitmq:
+    host: ${RABBITMQ_HOST:localhost}
+
   jpa:
     defer-datasource-initialization: true
     generate-ddl: true # Explicitly enable DDL generation by Hibernate

--- a/src/test/java/kr/it/pullit/modules/questionset/event/QuestionGenerationEventHandlerTest.java
+++ b/src/test/java/kr/it/pullit/modules/questionset/event/QuestionGenerationEventHandlerTest.java
@@ -1,40 +1,17 @@
 package kr.it.pullit.modules.questionset.event;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 
-import java.lang.reflect.Field;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import kr.it.pullit.modules.notification.api.NotificationEventPublicApi;
-import kr.it.pullit.modules.projection.learnstats.api.LearnStatsRecalibrationPublicApi;
-import kr.it.pullit.modules.questionset.api.QuestionPublicApi;
 import kr.it.pullit.modules.questionset.api.QuestionSetPublicApi;
-import kr.it.pullit.modules.questionset.client.dto.response.LlmGeneratedQuestionResponse;
-import kr.it.pullit.modules.questionset.client.dto.response.LlmGeneratedQuestionSetResponse;
-import kr.it.pullit.modules.questionset.domain.entity.Question;
-import kr.it.pullit.modules.questionset.domain.entity.QuestionSet;
-import kr.it.pullit.modules.questionset.enums.DifficultyType;
-import kr.it.pullit.modules.questionset.enums.QuestionType;
-import kr.it.pullit.modules.questionset.service.SourceValidator;
-import kr.it.pullit.modules.questionset.service.creationstrategy.QuestionCreationStrategy;
-import kr.it.pullit.modules.questionset.service.creationstrategy.QuestionCreationStrategyFactory;
-import kr.it.pullit.modules.questionset.web.dto.request.QuestionSetUpdateRequestDto;
-import kr.it.pullit.modules.questionset.web.dto.response.QuestionSetCreationCompleteResponse;
-import kr.it.pullit.modules.questionset.web.dto.response.QuestionSetResponse;
+import kr.it.pullit.platform.config.RabbitMqConfig;
 import kr.it.pullit.support.annotation.MockitoUnitTest;
 import kr.it.pullit.support.fixture.QuestionSetFixtures;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
 
 @MockitoUnitTest
 @DisplayName("QuestionGenerationEventHandler 단위 테스트")
@@ -42,110 +19,39 @@ class QuestionGenerationEventHandlerTest {
 
   @InjectMocks private QuestionGenerationEventHandler questionGenerationEventHandler;
 
-  @Mock private QuestionPublicApi questionPublicApi;
+  @Mock private RabbitTemplate rabbitTemplate;
   @Mock private QuestionSetPublicApi questionSetPublicApi;
-  @Mock private NotificationEventPublicApi notificationEventPublicApi;
-  @Mock private SourceValidator sourceValidator;
-  @Mock private QuestionCreationStrategyFactory questionCreationStrategyFactory;
-  @Mock private LearnStatsRecalibrationPublicApi learnStatsRecalibrationPublicApi;
 
   @Test
-  @DisplayName("문제집 생성 성공 시, 관련 API들이 순차적으로 호출되고 완료 상태로 변경된다")
-  void handleQuestionSetCreatedEvent_Success() throws Exception {
+  @DisplayName("문제집 생성 이벤트 수신 시, RabbitMQ로 메시지를 성공적으로 발행한다")
+  void handleQuestionSetCreatedEvent_Success() {
     // given
-    var questionSetWithoutId = QuestionSetFixtures.basic();
-    setIdUsingReflection(questionSetWithoutId, 1L);
-    var event = QuestionSetCreatedEvent.from(questionSetWithoutId);
-
-    var questionSetResponse = mock(QuestionSetResponse.class);
-    var llmResponse = mock(LlmGeneratedQuestionSetResponse.class);
-    var questionSet = mock(QuestionSet.class);
-    var creationStrategy = mock(QuestionCreationStrategy.class);
-    var question = mock(Question.class);
-
-    given(
-            questionSetPublicApi.getQuestionSetWhenHaveNoQuestionsYet(
-                event.questionSetId(), event.ownerId()))
-        .willReturn(questionSetResponse);
-    given(questionSetResponse.getSourceIds()).willReturn(List.of(1L));
-    given(questionSetResponse.getDifficulty()).willReturn(DifficultyType.EASY);
-    given(questionSetResponse.getType()).willReturn(QuestionType.MULTIPLE_CHOICE);
-    given(questionSetResponse.getQuestionLength()).willReturn(10);
-
-    given(questionPublicApi.generateQuestions(any())).willReturn(llmResponse);
-    given(llmResponse.title()).willReturn("생성된 문제집");
-    given(llmResponse.questions())
-        .willReturn(Collections.singletonList(mock(LlmGeneratedQuestionResponse.class)));
-    given(questionSetPublicApi.findEntityByIdAndMemberId(event.questionSetId(), event.ownerId()))
-        .willReturn(Optional.of(questionSet));
-    given(questionSet.getType()).willReturn(QuestionType.MULTIPLE_CHOICE);
-    given(questionCreationStrategyFactory.getStrategy(any(QuestionType.class)))
-        .willReturn(creationStrategy);
-    given(creationStrategy.create(any(), any())).willReturn(question);
-    given(
-            questionSetPublicApi.getQuestionSetForSolving(
-                event.questionSetId(), event.ownerId(), false))
-        .willReturn(questionSetResponse);
-    given(questionSetResponse.getId()).willReturn(event.questionSetId());
-    given(questionSetResponse.getTitle()).willReturn("생성된 문제집");
+    var questionSet = QuestionSetFixtures.basic();
+    var event = QuestionSetCreatedEvent.from(questionSet);
 
     // when
     questionGenerationEventHandler.handleQuestionSetCreatedEvent(event);
 
     // then
-    verify(sourceValidator).validateSourcesAreReady(any(), eq(event.questionSetId()));
-    verify(questionPublicApi).generateQuestions(any());
-    verify(questionPublicApi).saveQuestion(any(Question.class));
-    verify(questionSetPublicApi)
-        .updateAndMarkAsComplete(
-            eq(event.questionSetId()), any(QuestionSetUpdateRequestDto.class), eq(event.ownerId()));
-    verify(notificationEventPublicApi)
-        .publishQuestionSetCreationComplete(
-            eq(event.ownerId()), any(QuestionSetCreationCompleteResponse.class));
-    verify(learnStatsRecalibrationPublicApi)
-        .recalibrateTotalQuestionCountForMember(event.ownerId());
-    verify(questionSetPublicApi, never()).markAsFailed(anyLong());
+    verify(rabbitTemplate)
+        .convertAndSend(RabbitMqConfig.EXCHANGE_NAME, RabbitMqConfig.ROUTING_KEY, event);
   }
 
   @Test
-  @DisplayName("문제집 생성 중 예외 발생 시, 실패 상태로 변경되고 관련 API가 호출되지 않는다")
-  void handleQuestionSetCreatedEvent_Failure() throws Exception {
+  @DisplayName("메시지 발행 중 예외 발생 시, 문제집 상태를 FAILED로 변경한다")
+  void handleQuestionSetCreatedEvent_Failure() {
     // given
-    var questionSetWithoutId = QuestionSetFixtures.basic();
-    setIdUsingReflection(questionSetWithoutId, 1L);
-    var event = QuestionSetCreatedEvent.from(questionSetWithoutId);
+    var questionSet = QuestionSetFixtures.basic();
+    var event = QuestionSetCreatedEvent.from(questionSet);
 
-    var questionSetResponse = mock(QuestionSetResponse.class);
-
-    given(
-            questionSetPublicApi.getQuestionSetWhenHaveNoQuestionsYet(
-                event.questionSetId(), event.ownerId()))
-        .willReturn(questionSetResponse);
-    given(questionSetResponse.getSourceIds()).willReturn(List.of(1L));
-    given(questionSetResponse.getDifficulty()).willReturn(DifficultyType.EASY);
-    given(questionSetResponse.getType()).willReturn(QuestionType.MULTIPLE_CHOICE);
-    given(questionSetResponse.getQuestionLength()).willReturn(10);
-
-    willThrow(new RuntimeException("LLM API Error"))
-        .given(questionPublicApi)
-        .generateQuestions(any());
+    doThrow(new RuntimeException("MQ Broker connection failed"))
+        .when(rabbitTemplate)
+        .convertAndSend(RabbitMqConfig.EXCHANGE_NAME, RabbitMqConfig.ROUTING_KEY, event);
 
     // when
     questionGenerationEventHandler.handleQuestionSetCreatedEvent(event);
 
     // then
     verify(questionSetPublicApi).markAsFailed(event.questionSetId());
-    verify(questionSetPublicApi, never()).updateAndMarkAsComplete(anyLong(), any(), anyLong());
-    verify(questionPublicApi, never()).saveQuestion(any());
-    verify(notificationEventPublicApi, never())
-        .publishQuestionSetCreationComplete(anyLong(), any());
-    verify(learnStatsRecalibrationPublicApi, never())
-        .recalibrateTotalQuestionCountForMember(anyLong());
-  }
-
-  private void setIdUsingReflection(QuestionSet questionSet, Long id) throws Exception {
-    Field idField = QuestionSet.class.getDeclaredField("id");
-    idField.setAccessible(true);
-    idField.set(questionSet, id);
   }
 }

--- a/src/test/java/kr/it/pullit/modules/questionset/service/QuestionServiceTest.java
+++ b/src/test/java/kr/it/pullit/modules/questionset/service/QuestionServiceTest.java
@@ -6,7 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.io.ByteArrayInputStream;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import kr.it.pullit.modules.learningsource.source.api.SourcePublicApi;
@@ -47,13 +47,19 @@ class QuestionServiceTest {
   @Mock private QuestionSetRepository questionSetRepository;
   @Mock private SourcePublicApi sourcePublicApi;
   @Mock private LlmClient llmClient;
+  @Mock private QuestionSetFileTempManager questionSetFileTempManager;
 
   private QuestionService questionService;
 
   @BeforeEach
   void setUp() {
     questionService =
-        new QuestionService(questionRepository, questionSetRepository, sourcePublicApi, llmClient);
+        new QuestionService(
+            questionRepository,
+            questionSetRepository,
+            sourcePublicApi,
+            llmClient,
+            questionSetFileTempManager);
   }
 
   @Nested
@@ -61,8 +67,8 @@ class QuestionServiceTest {
   class DescribeGenerateQuestions {
 
     @Test
-    @DisplayName("LLM 클라이언트를 호출하여 문제를 생성한다")
-    void generatesQuestionsThroughLlm() {
+    @DisplayName("LLM 클라이언트를 호출하여 문제를 생성하고 임시 파일을 정리한다")
+    void generatesQuestionsThroughLlmAndCleansUpFiles() {
       Long memberId = 10L;
       Long questionSetId = 20L;
 
@@ -71,10 +77,12 @@ class QuestionServiceTest {
 
       when(questionSetRepository.findByIdAndMemberId(questionSetId, memberId))
           .thenReturn(Optional.of(questionSet));
-      when(sourcePublicApi.getContentStream(1L, memberId))
-          .thenReturn(new ByteArrayInputStream(new byte[] {1}));
-      when(sourcePublicApi.getContentStream(2L, memberId))
-          .thenReturn(new ByteArrayInputStream(new byte[] {2}));
+
+      Path path1 = Path.of("temp1.pdf");
+      Path path2 = Path.of("temp2.pdf");
+
+      when(sourcePublicApi.downloadFileToTemp(1L, memberId)).thenReturn(path1);
+      when(sourcePublicApi.downloadFileToTemp(2L, memberId)).thenReturn(path2);
 
       LlmGeneratedQuestionSetResponse expected =
           new LlmGeneratedQuestionSetResponse("제목", List.of());
@@ -94,10 +102,11 @@ class QuestionServiceTest {
       verify(llmClient).getLlmGeneratedQuestionContent(captor.capture());
       assertThat(captor.getValue().model()).isEqualTo("gemini-2.5-flash-lite");
       assertThat(captor.getValue().specification()).isEqualTo(specification);
-      assertThat(captor.getValue().fileDataList()).hasSize(2);
+      assertThat(captor.getValue().fileDataList()).containsExactly(path1, path2);
 
-      verify(sourcePublicApi).getContentStream(1L, memberId);
-      verify(sourcePublicApi).getContentStream(2L, memberId);
+      verify(sourcePublicApi).downloadFileToTemp(1L, memberId);
+      verify(sourcePublicApi).downloadFileToTemp(2L, memberId);
+      verify(questionSetFileTempManager).cleanUp(List.of(path1, path2));
     }
 
     @Test

--- a/src/test/java/kr/it/pullit/modules/questionset/service/QuestionServiceTest.java
+++ b/src/test/java/kr/it/pullit/modules/questionset/service/QuestionServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
@@ -68,7 +69,7 @@ class QuestionServiceTest {
 
     @Test
     @DisplayName("LLM 클라이언트를 호출하여 문제를 생성하고 임시 파일을 정리한다")
-    void generatesQuestionsThroughLlmAndCleansUpFiles() {
+    void generatesQuestionsThroughLlmAndCleansUpFiles() throws IOException {
       Long memberId = 10L;
       Long questionSetId = 20L;
 


### PR DESCRIPTION

## PR 설명

문제 생성 부분에 큐 도입하여 out of memory 문제 해결 및 rabbitmq 도입

### 요약

여러 사용자가 동시에 문제 생성을 요청하더라도 서버는 이제 무거운 연산을 즉시 수행하지 않는다.
대신 “사용자 A가 이런 작업을 요청했다”는 정보만 담은 작업 티켓을 생성해 **메시지 큐(대기열)**에 등록한다.
사용자에게는 **“요청이 정상적으로 접수되었습니다. 완료되면 알려드릴게요.”**라는 응답을 즉시 반환한다.(즉시 반환은 기존과 동일)

백그라운드에서 대기 중이던 **워커(주방장)**는 메시지 큐를 모니터링하다가 새 작업 티켓이 등록되면 하나를 가져와 처리하기 시작한다.
이때 워커는 S3에서 큰 크기의 PDF 파일을 다운로드할 때, 서버의 RAM이 아닌 S3(디스크 공간)을 사용해 메모리 사용량을 최소화한다.

임시 저장된 파일은 Gemini API로 전달되어 문제 생성 요청에 사용되고, 작업이 완료되면 결과물이 DB에 저장된다.
사용이 끝난 임시 파일은 즉시 삭제된다.

모든 처리가 끝난 뒤 워커는 사용자에게 “요청하신 문제집 생성이 완료되었습니다.”라는 알림을 전송한다.
이후 큐를 다시 확인하며 다음 작업 티켓을 처리한다.

| 항목 | 변경 전 (As-Is) | 변경 후 (To-Be) |
| :--- | :--- | :--- |
| **처리 방식** | 동기 처리 (요청 즉시 실행) | **비동기 처리 (큐에 등록 후 나중에 실행)** |
| **자원 사용** | 모든 파일을 메모리에 로드 | **파일을 임시 디스크에 저장** |
| **결과** | 동시 요청 시 메모리 부족으로 서버 다운 | **안정적으로 요청을 순차 처리하여 서버 안정성 확보** |

계산 공식  
> 최대 동시 워커 수 = (실제 작업에 사용 가능한 메모리) / (워커 1개가 사용하는 최대 메모리)

1. 실제 작업에 사용 가능한 메모리  
- A. 전체 JVM 힙 메모리 ~ 서버에 할당된 총 메모리임. (예: 512MB)  
- B. 안전 마진 (40%) ~ 갑작스러운 부하 증가에 대비한 예비 메모리임. (512MB * 0.4 = 205MB)  
- C. 애플리케이션 기본 사용량 ~ Spring Boot 등 애플리케이션 자체가 사용하는 메모리임. (보수적으로 200MB 추정)  
- 계산 ~ A - B - C = 512 - 205 - 200 = 107MB

2. 워커 1개가 사용하는 최대 메모리  
- 이는 사용자가 업로드하는 최대 파일 크기와 같음. (예: 40MB)

3. 최종 워커 수 계산  
- 107MB / 40MB = 2.675  
- 계산 결과, 동시에 실행 가능한 워커는 최대 2명임.  


<!--Release Notes:

- N/A _or_ Added/Fixed/Improved ...-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Question generation is now asynchronous via a message queue with a dedicated worker, improving scalability and reliability.
  * Temporary file download and cleanup for source documents have been added to ensure safe LLM processing.

* **Chores**
  * RabbitMQ broker and related runtime configuration added to deployment and app settings.
  * Dependency and test updates to support the new message-based workflow and temp-file handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->