### PR TITLE
btsk-113: 메세지큐를 통해 문제생성시 sse 연결이 제대로 안되는 문제 해결

### DIFF
--- a/src/main/java/kr/it/pullit/modules/questionset/client/GeminiClient.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/client/GeminiClient.java
@@ -86,6 +86,15 @@ public class GeminiClient implements LlmClient {
 
   private LlmGeneratedQuestionSetResponse parseResponse(GenerateContentResponse response)
       throws IOException {
-    return mapper.readValue(response.text(), LlmGeneratedQuestionSetResponse.class);
+    String rawResponse = response.text();
+    try {
+      return mapper.readValue(rawResponse, LlmGeneratedQuestionSetResponse.class);
+    } catch (IOException e) {
+      log.error(
+          "Gemini API 응답 파싱에 실패했습니다. 원본 응답을 에러 로그에 첨부합니다.\n--- 원본 응답 ---\n{}\n--- 원본 응답 끝 ---",
+          rawResponse,
+          e);
+      throw e;
+    }
   }
 }

--- a/src/main/java/kr/it/pullit/modules/questionset/event/QuestionGenerationWorker.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/event/QuestionGenerationWorker.java
@@ -1,8 +1,6 @@
 package kr.it.pullit.modules.questionset.event;
 
 import java.util.List;
-import kr.it.pullit.modules.notification.api.NotificationEventPublicApi;
-import kr.it.pullit.modules.projection.learnstats.api.LearnStatsRecalibrationPublicApi;
 import kr.it.pullit.modules.questionset.api.QuestionPublicApi;
 import kr.it.pullit.modules.questionset.api.QuestionSetPublicApi;
 import kr.it.pullit.modules.questionset.client.dto.response.LlmGeneratedQuestionResponse;
@@ -14,12 +12,12 @@ import kr.it.pullit.modules.questionset.domain.entity.QuestionSet;
 import kr.it.pullit.modules.questionset.service.SourceValidator;
 import kr.it.pullit.modules.questionset.service.creationstrategy.QuestionCreationStrategyFactory;
 import kr.it.pullit.modules.questionset.web.dto.request.QuestionSetUpdateRequestDto;
-import kr.it.pullit.modules.questionset.web.dto.response.QuestionSetCreationCompleteResponse;
 import kr.it.pullit.modules.questionset.web.dto.response.QuestionSetResponse;
 import kr.it.pullit.platform.config.RabbitMqConfig;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
@@ -29,12 +27,11 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class QuestionGenerationWorker {
 
+  private final RabbitTemplate rabbitTemplate;
   private final QuestionPublicApi questionPublicApi;
   private final QuestionSetPublicApi questionSetPublicApi;
-  private final NotificationEventPublicApi notificationEventPublicApi;
   private final SourceValidator sourceValidator;
   private final QuestionCreationStrategyFactory questionCreationStrategyFactory;
-  private final LearnStatsRecalibrationPublicApi learnStatsRecalibrationPublicApi;
 
   @RabbitListener(queues = RabbitMqConfig.QUEUE_NAME)
   public void handleQuestionGenerationRequest(QuestionSetCreatedEvent event) {
@@ -117,18 +114,13 @@ public class QuestionGenerationWorker {
   }
 
   private void handleSuccess(QuestionSetCreatedEvent event) {
-    QuestionSetCreationCompleteResponse responseDto = createSuccessResponse(event);
-    notificationEventPublicApi.publishQuestionSetCreationComplete(event.ownerId(), responseDto);
-    learnStatsRecalibrationPublicApi.recalibrateTotalQuestionCountForMember(event.ownerId());
     log.info("AI 문제 생성이 완료되었습니다. QuestionSet ID: {}", event.questionSetId());
-  }
-
-  private QuestionSetCreationCompleteResponse createSuccessResponse(QuestionSetCreatedEvent event) {
-    QuestionSetResponse questionSetResponse =
-        questionSetPublicApi.getQuestionSetForSolving(
-            event.questionSetId(), event.ownerId(), false);
-    return new QuestionSetCreationCompleteResponse(
-        true, questionSetResponse.getId(), "문제집 생성 완료 (" + questionSetResponse.getTitle() + ")");
+    QuestionSetCompletionEvent completionEvent =
+        new QuestionSetCompletionEvent(event.questionSetId(), event.ownerId());
+    rabbitTemplate.convertAndSend(
+        RabbitMqConfig.COMPLETION_EXCHANGE_NAME,
+        RabbitMqConfig.COMPLETION_ROUTING_KEY,
+        completionEvent);
   }
 
   private void handleFailure(QuestionSetCreatedEvent event, Exception e) {

--- a/src/main/java/kr/it/pullit/modules/questionset/event/QuestionSetCompletionEvent.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/event/QuestionSetCompletionEvent.java
@@ -1,0 +1,3 @@
+package kr.it.pullit.modules.questionset.event;
+
+public record QuestionSetCompletionEvent(Long questionSetId, Long ownerId) {}

--- a/src/main/java/kr/it/pullit/modules/questionset/event/QuestionSetCompletionEventHandler.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/event/QuestionSetCompletionEventHandler.java
@@ -1,0 +1,47 @@
+package kr.it.pullit.modules.questionset.event;
+
+import kr.it.pullit.modules.notification.api.NotificationEventPublicApi;
+import kr.it.pullit.modules.projection.learnstats.api.LearnStatsRecalibrationPublicApi;
+import kr.it.pullit.modules.questionset.api.QuestionSetPublicApi;
+import kr.it.pullit.modules.questionset.web.dto.response.QuestionSetCreationCompleteResponse;
+import kr.it.pullit.modules.questionset.web.dto.response.QuestionSetResponse;
+import kr.it.pullit.platform.config.RabbitMqConfig;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@Profile("!worker")
+@RequiredArgsConstructor
+public class QuestionSetCompletionEventHandler {
+
+  private final NotificationEventPublicApi notificationEventPublicApi;
+  private final QuestionSetPublicApi questionSetPublicApi;
+  private final LearnStatsRecalibrationPublicApi learnStatsRecalibrationPublicApi;
+
+  @RabbitListener(queues = RabbitMqConfig.COMPLETION_QUEUE_NAME)
+  public void handleQuestionSetCompletion(QuestionSetCompletionEvent event) {
+    log.info(
+        "문제집 생성 완료 이벤트를 수신했습니다. QuestionSet ID: {}, Owner ID: {}",
+        event.questionSetId(),
+        event.ownerId());
+
+    QuestionSetCreationCompleteResponse responseDto = createSuccessResponse(event);
+    notificationEventPublicApi.publishQuestionSetCreationComplete(event.ownerId(), responseDto);
+    learnStatsRecalibrationPublicApi.recalibrateTotalQuestionCountForMember(event.ownerId());
+
+    log.info("사용자에게 SSE 알림을 전송하고 통계 정보를 갱신했습니다. QuestionSet ID: {}", event.questionSetId());
+  }
+
+  private QuestionSetCreationCompleteResponse createSuccessResponse(
+      QuestionSetCompletionEvent event) {
+    QuestionSetResponse questionSetResponse =
+        questionSetPublicApi.getQuestionSetForSolving(
+            event.questionSetId(), event.ownerId(), false);
+    return new QuestionSetCreationCompleteResponse(
+        true, questionSetResponse.getId(), "문제집 생성 완료 (" + questionSetResponse.getTitle() + ")");
+  }
+}

--- a/src/main/java/kr/it/pullit/modules/questionset/service/SourceValidator.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/service/SourceValidator.java
@@ -41,18 +41,8 @@ public class SourceValidator {
 
   private void handleNotReadySources(List<Source> notReadySources, Long questionSetId) {
     if (!notReadySources.isEmpty()) {
-      logErrorsForNotReadySources(notReadySources);
       throw createException(notReadySources);
     }
-  }
-
-  private void logErrorsForNotReadySources(List<Source> notReadySources) {
-    notReadySources.forEach(
-        source ->
-            log.error(
-                "소스 파일이 준비되지 않았습니다. Source ID: {}, Status: {}",
-                source.getId(),
-                source.getStatus()));
   }
 
   private SourceNotReadyException createException(List<Source> notReadySources) {

--- a/src/main/java/kr/it/pullit/platform/config/RabbitMqConfig.java
+++ b/src/main/java/kr/it/pullit/platform/config/RabbitMqConfig.java
@@ -18,6 +18,10 @@ public class RabbitMqConfig {
   public static final String QUEUE_NAME = "question.generation.queue";
   public static final String ROUTING_KEY = "question.generation.request";
 
+  public static final String COMPLETION_EXCHANGE_NAME = "question.completion.exchange";
+  public static final String COMPLETION_QUEUE_NAME = "question.completion.queue";
+  public static final String COMPLETION_ROUTING_KEY = "question.completion.success";
+
   @Bean
   public TopicExchange exchange() {
     return new TopicExchange(EXCHANGE_NAME);
@@ -33,6 +37,23 @@ public class RabbitMqConfig {
   @Bean
   public Binding binding(Queue queue, TopicExchange exchange) {
     return BindingBuilder.bind(queue).to(exchange).with(ROUTING_KEY);
+  }
+
+  @Bean
+  public TopicExchange completionExchange() {
+    return new TopicExchange(COMPLETION_EXCHANGE_NAME);
+  }
+
+  @Bean
+  public Queue completionQueue() {
+    return new Queue(COMPLETION_QUEUE_NAME, true);
+  }
+
+  @Bean
+  public Binding completionBinding() {
+    return BindingBuilder.bind(completionQueue())
+        .to(completionExchange())
+        .with(COMPLETION_ROUTING_KEY);
   }
 
   @Bean

--- a/src/main/java/kr/it/pullit/platform/config/RabbitMqConfig.java
+++ b/src/main/java/kr/it/pullit/platform/config/RabbitMqConfig.java
@@ -8,6 +8,7 @@ import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -35,7 +36,8 @@ public class RabbitMqConfig {
   }
 
   @Bean
-  public Binding binding(Queue queue, TopicExchange exchange) {
+  public Binding binding(
+      @Qualifier("queue") Queue queue, @Qualifier("exchange") TopicExchange exchange) {
     return BindingBuilder.bind(queue).to(exchange).with(ROUTING_KEY);
   }
 
@@ -50,10 +52,10 @@ public class RabbitMqConfig {
   }
 
   @Bean
-  public Binding completionBinding() {
-    return BindingBuilder.bind(completionQueue())
-        .to(completionExchange())
-        .with(COMPLETION_ROUTING_KEY);
+  public Binding completionBinding(
+      @Qualifier("completionQueue") Queue completionQueue,
+      @Qualifier("completionExchange") TopicExchange completionExchange) {
+    return BindingBuilder.bind(completionQueue).to(completionExchange).with(COMPLETION_ROUTING_KEY);
   }
 
   @Bean


### PR DESCRIPTION
<!-- PR 제목을 `이슈번호: 작업내용(명확히)`로 작성해주세요. -->

## PR 설명

문제 생성이 완료되면, 작업자 앱이 notificationEventPublicApi.publishQuestionSetCreationComplete()를 호출하여 SSE 알림을 보내려고 합니다.
하지만 실제 사용자의 SSE 연결 정보는 메인 앱에만 존재합니다. 작업자 앱은 어떤 사용자가 연결되어 있는지 전혀 모르기 때문에, 이 호출은 허공에 메시지를 보내는 것과 같아 아무런 효과가 없습니다. 결국 사용자에게 알림이 가지 않습니다.

=> 작업 완료 사실을 다시 RabbitMQ를 통해 메인 앱에게 알려주도록 feature 추가 

<!--Release Notes:

- N/A _or_ Added/Fixed/Improved ...-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Question set completion is now processed via an asynchronous message path, preserving notifications and user statistics updates while improving reliability and scalability.

* **Bug Fixes**
  * Parsing errors now log the original response for clearer diagnostics.

* **Chores**
  * Simplified source readiness handling to fail fast when sources are not ready.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->