### PR TITLE
btsk-114: 문제집 생성시 낙관적락을 비관적 락으로 변경

### DIFF
--- a/scripts/deploy-qa.sh
+++ b/scripts/deploy-qa.sh
@@ -96,3 +96,7 @@ docker compose -f docker-compose.qa.yml stop "pullit-qa-$PREVIOUS_ACTIVE_COLOR"
 # 6. 이전 버전 워커 서버 컨테이너 종료
 echo "이전 버전 워커 서버($PREVIOUS_ACTIVE_COLOR)를 종료합니다."
 docker compose -f docker-compose.qa.yml stop "pullit-qa-worker-$PREVIOUS_ACTIVE_COLOR"
+
+# 7. 프로메테우스 설정 리로드
+echo "프로메테우스가 새 설정을 읽도록 재시작합니다."
+docker compose -f docker-compose.qa.yml restart prometheus

--- a/src/main/java/kr/it/pullit/modules/questionset/api/QuestionSetPublicApi.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/api/QuestionSetPublicApi.java
@@ -35,7 +35,7 @@ public interface QuestionSetPublicApi {
 
   List<QuestionSet> findStalePending(LocalDateTime threshold);
 
-  Optional<QuestionSet> findFirstFailedSetForRetry(int maxRetryCount);
+  Optional<QuestionSet> claimOneForRetry(int maxRetryCount);
 
   Optional<QuestionSet> findEntityByIdAndMemberId(Long id, Long memberId);
 

--- a/src/main/java/kr/it/pullit/modules/questionset/repository/QuestionSetRepository.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/repository/QuestionSetRepository.java
@@ -49,4 +49,6 @@ public interface QuestionSetRepository {
       Long memberId, LocalDateTime start, LocalDateTime end);
 
   List<LocalDateTime> findCompletedDatesByMemberId(Long memberId);
+
+  void relocateAllByFolderIdToDefaultFolder(Long folderId, Long defaultFolderId);
 }

--- a/src/main/java/kr/it/pullit/modules/questionset/repository/QuestionSetRepository.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/repository/QuestionSetRepository.java
@@ -31,7 +31,7 @@ public interface QuestionSetRepository {
   List<QuestionSet> findByStatusAndCreatedAtBefore(
       QuestionSetStatus status, LocalDateTime threshold);
 
-  Optional<QuestionSet> findFirstFailedSetForRetry(int maxRetryCount);
+  Optional<QuestionSet> findFirstFailedSetForRetryForUpdate(int maxRetry);
 
   QuestionSet save(QuestionSet questionSet);
 

--- a/src/main/java/kr/it/pullit/modules/questionset/repository/QuestionSetRepositoryImpl.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/repository/QuestionSetRepositoryImpl.java
@@ -3,13 +3,13 @@ package kr.it.pullit.modules.questionset.repository;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Repository;
 import kr.it.pullit.modules.questionset.domain.entity.QuestionSet;
 import kr.it.pullit.modules.questionset.enums.QuestionSetStatus;
 import kr.it.pullit.modules.questionset.repository.adapter.jpa.QuestionSetJpaRepository;
 import kr.it.pullit.modules.questionset.web.dto.response.QuestionSetResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
@@ -132,5 +132,10 @@ public class QuestionSetRepositoryImpl implements QuestionSetRepository {
   @Override
   public List<LocalDateTime> findCompletedDatesByMemberId(Long memberId) {
     return questionSetJpaRepository.findCompletedDatesByMemberId(memberId);
+  }
+
+  @Override
+  public void relocateAllByFolderIdToDefaultFolder(Long folderId, Long defaultFolderId) {
+    questionSetJpaRepository.relocateAllByFolderIdToDefaultFolder(folderId, defaultFolderId);
   }
 }

--- a/src/main/java/kr/it/pullit/modules/questionset/repository/QuestionSetRepositoryImpl.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/repository/QuestionSetRepositoryImpl.java
@@ -3,13 +3,13 @@ package kr.it.pullit.modules.questionset.repository;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.stereotype.Repository;
 import kr.it.pullit.modules.questionset.domain.entity.QuestionSet;
 import kr.it.pullit.modules.questionset.enums.QuestionSetStatus;
 import kr.it.pullit.modules.questionset.repository.adapter.jpa.QuestionSetJpaRepository;
 import kr.it.pullit.modules.questionset.web.dto.response.QuestionSetResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor

--- a/src/main/java/kr/it/pullit/modules/questionset/repository/QuestionSetRepositoryImpl.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/repository/QuestionSetRepositoryImpl.java
@@ -99,10 +99,7 @@ public class QuestionSetRepositoryImpl implements QuestionSetRepository {
 
   @Override
   public Optional<QuestionSet> findFirstFailedSetForRetryForUpdate(int maxRetry) {
-    return questionSetJpaRepository
-        .findFirstFailedSetForRetryForUpdate(maxRetry, PageRequest.of(0, 1))
-        .stream()
-        .findFirst();
+    return questionSetJpaRepository.findFirstFailedSetForRetryForUpdate(maxRetry);
   }
 
   @Override

--- a/src/main/java/kr/it/pullit/modules/questionset/repository/QuestionSetRepositoryImpl.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/repository/QuestionSetRepositoryImpl.java
@@ -98,9 +98,11 @@ public class QuestionSetRepositoryImpl implements QuestionSetRepository {
   }
 
   @Override
-  public Optional<QuestionSet> findFirstFailedSetForRetry(int maxRetryCount) {
-    return questionSetJpaRepository.findFirstByStatusAndRetryCountLessThanOrderByCreatedAtAsc(
-        QuestionSetStatus.FAILED, maxRetryCount);
+  public Optional<QuestionSet> findFirstFailedSetForRetryForUpdate(int maxRetry) {
+    return questionSetJpaRepository
+        .findFirstFailedSetForRetryForUpdate(maxRetry, PageRequest.of(0, 1))
+        .stream()
+        .findFirst();
   }
 
   @Override

--- a/src/main/java/kr/it/pullit/modules/questionset/repository/adapter/jpa/QuestionSetJpaRepository.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/repository/adapter/jpa/QuestionSetJpaRepository.java
@@ -152,7 +152,11 @@ public interface QuestionSetJpaRepository extends JpaRepository<QuestionSet, Lon
   @Modifying
   @Query(
       value =
-          "UPDATE question_set SET common_folder_id = :defaultFolderId WHERE common_folder_id = :folderId",
+          """
+            UPDATE question_set
+            SET common_folder_id = :defaultFolderId
+            WHERE common_folder_id = :folderId
+          """,
       nativeQuery = true)
   void relocateAllByFolderIdToDefaultFolder(
       @Param("folderId") Long folderId, @Param("defaultFolderId") Long defaultFolderId);

--- a/src/main/java/kr/it/pullit/modules/questionset/repository/adapter/jpa/QuestionSetJpaRepository.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/repository/adapter/jpa/QuestionSetJpaRepository.java
@@ -1,5 +1,6 @@
 package kr.it.pullit.modules.questionset.repository.adapter.jpa;
 
+import jakarta.persistence.LockModeType;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -7,6 +8,7 @@ import kr.it.pullit.modules.questionset.domain.entity.QuestionSet;
 import kr.it.pullit.modules.questionset.enums.QuestionSetStatus;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -15,8 +17,16 @@ public interface QuestionSetJpaRepository extends JpaRepository<QuestionSet, Lon
   List<QuestionSet> findByStatusAndCreatedAtBefore(
       QuestionSetStatus status, LocalDateTime threshold);
 
-  Optional<QuestionSet> findFirstByStatusAndRetryCountLessThanOrderByCreatedAtAsc(
-      QuestionSetStatus status, int maxRetryCount);
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query(
+      """
+        select q from QuestionSet q
+        where q.status = kr.it.pullit.modules.questionset.enums.QuestionSetStatus.FAILED
+          and q.retryCount < :maxRetry
+        order by q.id asc
+      """)
+  List<QuestionSet> findFirstFailedSetForRetryForUpdate(
+      @Param("maxRetry") int maxRetry, Pageable pageable);
 
   @Query(
       """

--- a/src/main/java/kr/it/pullit/modules/questionset/repository/adapter/jpa/QuestionSetJpaRepository.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/repository/adapter/jpa/QuestionSetJpaRepository.java
@@ -1,24 +1,21 @@
 package kr.it.pullit.modules.questionset.repository.adapter.jpa;
 
-import jakarta.persistence.LockModeType;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-import kr.it.pullit.modules.questionset.domain.entity.QuestionSet;
-import kr.it.pullit.modules.questionset.enums.QuestionSetStatus;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import kr.it.pullit.modules.questionset.domain.entity.QuestionSet;
+import kr.it.pullit.modules.questionset.enums.QuestionSetStatus;
 
 public interface QuestionSetJpaRepository extends JpaRepository<QuestionSet, Long> {
 
   List<QuestionSet> findByStatusAndCreatedAtBefore(
       QuestionSetStatus status, LocalDateTime threshold);
 
-  @Lock(LockModeType.PESSIMISTIC_WRITE)
   @Query(
       value =
           """

--- a/src/main/java/kr/it/pullit/modules/questionset/repository/adapter/jpa/QuestionSetJpaRepository.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/repository/adapter/jpa/QuestionSetJpaRepository.java
@@ -3,13 +3,13 @@ package kr.it.pullit.modules.questionset.repository.adapter.jpa;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-import kr.it.pullit.modules.questionset.domain.entity.QuestionSet;
-import kr.it.pullit.modules.questionset.enums.QuestionSetStatus;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import kr.it.pullit.modules.questionset.domain.entity.QuestionSet;
+import kr.it.pullit.modules.questionset.enums.QuestionSetStatus;
 
 public interface QuestionSetJpaRepository extends JpaRepository<QuestionSet, Long> {
 

--- a/src/main/java/kr/it/pullit/modules/questionset/repository/adapter/jpa/QuestionSetJpaRepository.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/repository/adapter/jpa/QuestionSetJpaRepository.java
@@ -3,13 +3,13 @@ package kr.it.pullit.modules.questionset.repository.adapter.jpa;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import kr.it.pullit.modules.questionset.domain.entity.QuestionSet;
+import kr.it.pullit.modules.questionset.enums.QuestionSetStatus;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import kr.it.pullit.modules.questionset.domain.entity.QuestionSet;
-import kr.it.pullit.modules.questionset.enums.QuestionSetStatus;
 
 public interface QuestionSetJpaRepository extends JpaRepository<QuestionSet, Long> {
 

--- a/src/main/java/kr/it/pullit/modules/questionset/repository/adapter/jpa/QuestionSetJpaRepository.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/repository/adapter/jpa/QuestionSetJpaRepository.java
@@ -1,17 +1,17 @@
 package kr.it.pullit.modules.questionset.repository.adapter.jpa;
 
+import jakarta.persistence.LockModeType;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import kr.it.pullit.modules.questionset.domain.entity.QuestionSet;
+import kr.it.pullit.modules.questionset.enums.QuestionSetStatus;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import jakarta.persistence.LockModeType;
-import kr.it.pullit.modules.questionset.domain.entity.QuestionSet;
-import kr.it.pullit.modules.questionset.enums.QuestionSetStatus;
 
 public interface QuestionSetJpaRepository extends JpaRepository<QuestionSet, Long> {
 
@@ -151,7 +151,8 @@ public interface QuestionSetJpaRepository extends JpaRepository<QuestionSet, Lon
 
   @Modifying
   @Query(
-      value = "UPDATE question_set SET common_folder_id = :defaultFolderId WHERE common_folder_id = :folderId",
+      value =
+          "UPDATE question_set SET common_folder_id = :defaultFolderId WHERE common_folder_id = :folderId",
       nativeQuery = true)
   void relocateAllByFolderIdToDefaultFolder(
       @Param("folderId") Long folderId, @Param("defaultFolderId") Long defaultFolderId);

--- a/src/main/java/kr/it/pullit/modules/questionset/repository/adapter/jpa/QuestionSetJpaRepository.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/repository/adapter/jpa/QuestionSetJpaRepository.java
@@ -20,14 +20,17 @@ public interface QuestionSetJpaRepository extends JpaRepository<QuestionSet, Lon
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @Query(
-      """
-        select q from QuestionSet q
-        where q.status = kr.it.pullit.modules.questionset.enums.QuestionSetStatus.FAILED
-          and q.retryCount < :maxRetry
-        order by q.id asc
-      """)
-  List<QuestionSet> findFirstFailedSetForRetryForUpdate(
-      @Param("maxRetry") int maxRetry, Pageable pageable);
+      value =
+          """
+        SELECT * FROM question_set
+        WHERE status = 'FAILED'
+          AND retry_count < :maxRetry
+        ORDER BY id
+        LIMIT 1
+        FOR UPDATE SKIP LOCKED
+      """,
+      nativeQuery = true)
+  Optional<QuestionSet> findFirstFailedSetForRetryForUpdate(@Param("maxRetry") int maxRetry);
 
   @Query(
       """
@@ -149,7 +152,7 @@ public interface QuestionSetJpaRepository extends JpaRepository<QuestionSet, Lon
       """)
   List<LocalDateTime> findCompletedDatesByMemberId(@Param("memberId") Long memberId);
 
-  @Modifying
+  @Modifying(clearAutomatically = true)
   @Query(
       value =
           """

--- a/src/main/java/kr/it/pullit/modules/questionset/repository/adapter/jpa/QuestionSetJpaRepository.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/repository/adapter/jpa/QuestionSetJpaRepository.java
@@ -1,16 +1,17 @@
 package kr.it.pullit.modules.questionset.repository.adapter.jpa;
 
-import jakarta.persistence.LockModeType;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-import kr.it.pullit.modules.questionset.domain.entity.QuestionSet;
-import kr.it.pullit.modules.questionset.enums.QuestionSetStatus;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import jakarta.persistence.LockModeType;
+import kr.it.pullit.modules.questionset.domain.entity.QuestionSet;
+import kr.it.pullit.modules.questionset.enums.QuestionSetStatus;
 
 public interface QuestionSetJpaRepository extends JpaRepository<QuestionSet, Long> {
 
@@ -147,4 +148,11 @@ public interface QuestionSetJpaRepository extends JpaRepository<QuestionSet, Lon
           ORDER BY q.createdAt ASC
       """)
   List<LocalDateTime> findCompletedDatesByMemberId(@Param("memberId") Long memberId);
+
+  @Modifying
+  @Query(
+      value = "UPDATE question_set SET common_folder_id = :defaultFolderId WHERE common_folder_id = :folderId",
+      nativeQuery = true)
+  void relocateAllByFolderIdToDefaultFolder(
+      @Param("folderId") Long folderId, @Param("defaultFolderId") Long defaultFolderId);
 }

--- a/src/main/java/kr/it/pullit/modules/questionset/scheduler/QuestionSetRetryScheduler.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/scheduler/QuestionSetRetryScheduler.java
@@ -8,7 +8,6 @@ import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Component
@@ -25,19 +24,17 @@ public class QuestionSetRetryScheduler {
       name = "retryFailedQuestionSetGeneration",
       lockAtMostFor = "4m",
       lockAtLeastFor = "1m")
-  @Transactional
   public void retryFailedQuestionSetGeneration() {
     log.info("'생성실패' 상태의 문제집 재시도 작업을 시작합니다.");
 
     questionSetPublicApi
-        .findFirstFailedSetForRetry(MAX_RETRY_COUNT)
+        .claimOneForRetry(MAX_RETRY_COUNT)
         .ifPresent(
             questionSet -> {
               log.info(
                   "문제집 ID {} (재시도 횟수: {}) 재생성을 시작합니다.",
                   questionSet.getId(),
                   questionSet.getRetryCount());
-              questionSet.retry();
               eventPublisher.publish(QuestionSetCreatedEvent.from(questionSet));
               log.info("문제집 ID {}에 대한 재생성 이벤트를 발행했습니다.", questionSet.getId());
             });

--- a/src/main/java/kr/it/pullit/modules/questionset/service/QuestionSetService.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/service/QuestionSetService.java
@@ -3,6 +3,8 @@ package kr.it.pullit.modules.questionset.service;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import kr.it.pullit.modules.commonfolder.api.CommonFolderPublicApi;
 import kr.it.pullit.modules.commonfolder.domain.entity.CommonFolder;
 import kr.it.pullit.modules.learningsource.source.api.SourcePublicApi;
@@ -32,8 +34,6 @@ import kr.it.pullit.shared.error.BusinessException;
 import kr.it.pullit.shared.event.EventPublisher;
 import kr.it.pullit.shared.paging.dto.CursorPageResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -257,6 +257,10 @@ public class QuestionSetService implements QuestionSetPublicApi {
   @Override
   @Transactional
   public void relocateQuestionSetsToDefaultFolder(Long memberId, Long folderId) {
+    commonFolderPublicApi
+        .findFolderEntityById(memberId, folderId)
+        .orElseThrow(() -> new IllegalArgumentException("해당 ID의 폴더를 찾을 수 없거나 권한이 없습니다."));
+
     CommonFolder defaultFolder =
         commonFolderPublicApi.getOrCreateDefaultQuestionSetFolder(memberId);
     questionSetRepository.relocateAllByFolderIdToDefaultFolder(folderId, defaultFolder.getId());

--- a/src/main/java/kr/it/pullit/modules/questionset/service/QuestionSetService.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/service/QuestionSetService.java
@@ -276,9 +276,15 @@ public class QuestionSetService implements QuestionSetPublicApi {
   }
 
   @Override
-  @Transactional(readOnly = true)
-  public Optional<QuestionSet> findFirstFailedSetForRetry(int maxRetryCount) {
-    return questionSetRepository.findFirstFailedSetForRetry(maxRetryCount);
+  @Transactional
+  public Optional<QuestionSet> claimOneForRetry(int maxRetryCount) {
+    return questionSetRepository
+        .findFirstFailedSetForRetryForUpdate(maxRetryCount)
+        .map(
+            questionSet -> {
+              questionSet.retry();
+              return questionSet;
+            });
   }
 
   @Override

--- a/src/main/java/kr/it/pullit/modules/questionset/service/QuestionSetService.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/service/QuestionSetService.java
@@ -3,8 +3,6 @@ package kr.it.pullit.modules.questionset.service;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import kr.it.pullit.modules.commonfolder.api.CommonFolderPublicApi;
 import kr.it.pullit.modules.commonfolder.domain.entity.CommonFolder;
 import kr.it.pullit.modules.learningsource.source.api.SourcePublicApi;
@@ -34,6 +32,8 @@ import kr.it.pullit.shared.error.BusinessException;
 import kr.it.pullit.shared.event.EventPublisher;
 import kr.it.pullit.shared.paging.dto.CursorPageResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/kr/it/pullit/modules/questionset/service/QuestionSetService.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/service/QuestionSetService.java
@@ -3,6 +3,8 @@ package kr.it.pullit.modules.questionset.service;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import kr.it.pullit.modules.commonfolder.api.CommonFolderPublicApi;
 import kr.it.pullit.modules.commonfolder.domain.entity.CommonFolder;
 import kr.it.pullit.modules.learningsource.source.api.SourcePublicApi;
@@ -32,8 +34,6 @@ import kr.it.pullit.shared.error.BusinessException;
 import kr.it.pullit.shared.event.EventPublisher;
 import kr.it.pullit.shared.paging.dto.CursorPageResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -259,8 +259,7 @@ public class QuestionSetService implements QuestionSetPublicApi {
   public void relocateQuestionSetsToDefaultFolder(Long memberId, Long folderId) {
     CommonFolder defaultFolder =
         commonFolderPublicApi.getOrCreateDefaultQuestionSetFolder(memberId);
-    List<QuestionSet> questionSets = questionSetRepository.findAllByCommonFolderId(folderId);
-    questionSets.forEach(questionSet -> questionSet.assignToFolder(defaultFolder));
+    questionSetRepository.relocateAllByFolderIdToDefaultFolder(folderId, defaultFolder.getId());
   }
 
   @Override

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,6 +36,10 @@ spring:
   flyway:
     enabled: false
 
+  threads:
+    virtual:
+      enabled: true
+
   security:
     oauth2:
       client:

--- a/src/test/java/kr/it/pullit/modules/questionset/scheduler/QuestionSetRetrySchedulerTest.java
+++ b/src/test/java/kr/it/pullit/modules/questionset/scheduler/QuestionSetRetrySchedulerTest.java
@@ -6,18 +6,17 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
 import java.util.Optional;
-import kr.it.pullit.modules.questionset.api.QuestionSetPublicApi;
-import kr.it.pullit.modules.questionset.domain.entity.QuestionSet;
-import kr.it.pullit.modules.questionset.event.QuestionSetCreatedEvent;
-import kr.it.pullit.shared.event.EventPublisher;
-import kr.it.pullit.support.annotation.SpringUnitTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import kr.it.pullit.modules.questionset.api.QuestionSetPublicApi;
+import kr.it.pullit.modules.questionset.domain.entity.QuestionSet;
+import kr.it.pullit.modules.questionset.event.QuestionSetCreatedEvent;
+import kr.it.pullit.shared.event.EventPublisher;
+import kr.it.pullit.support.annotation.SpringUnitTest;
 
 @SpringUnitTest
 @ContextConfiguration(classes = {QuestionSetRetryScheduler.class})
@@ -42,7 +41,6 @@ class QuestionSetRetrySchedulerTest {
     questionSetRetryScheduler.retryFailedQuestionSetGeneration();
 
     // then
-    verify(retryableSet, times(1)).retry();
     verify(eventPublisher, times(1)).publish(any(QuestionSetCreatedEvent.class));
   }
 

--- a/src/test/java/kr/it/pullit/modules/questionset/scheduler/QuestionSetRetrySchedulerTest.java
+++ b/src/test/java/kr/it/pullit/modules/questionset/scheduler/QuestionSetRetrySchedulerTest.java
@@ -6,17 +6,18 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
 import java.util.Optional;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import kr.it.pullit.modules.questionset.api.QuestionSetPublicApi;
 import kr.it.pullit.modules.questionset.domain.entity.QuestionSet;
 import kr.it.pullit.modules.questionset.event.QuestionSetCreatedEvent;
 import kr.it.pullit.shared.event.EventPublisher;
 import kr.it.pullit.support.annotation.SpringUnitTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringUnitTest
 @ContextConfiguration(classes = {QuestionSetRetryScheduler.class})

--- a/src/test/java/kr/it/pullit/modules/questionset/scheduler/QuestionSetRetrySchedulerTest.java
+++ b/src/test/java/kr/it/pullit/modules/questionset/scheduler/QuestionSetRetrySchedulerTest.java
@@ -36,7 +36,7 @@ class QuestionSetRetrySchedulerTest {
     // given
     QuestionSet retryableSet = mock(QuestionSet.class);
 
-    when(questionSetPublicApi.findFirstFailedSetForRetry(3)).thenReturn(Optional.of(retryableSet));
+    when(questionSetPublicApi.claimOneForRetry(3)).thenReturn(Optional.of(retryableSet));
 
     // when
     questionSetRetryScheduler.retryFailedQuestionSetGeneration();
@@ -50,7 +50,7 @@ class QuestionSetRetrySchedulerTest {
   @DisplayName("재시도할 문제집이 없으면 아무 작업도 하지 않는다")
   void retryFailedQuestionSetGeneration_whenNoRetryableSets_doesNothing() {
     // given
-    when(questionSetPublicApi.findFirstFailedSetForRetry(3)).thenReturn(Optional.empty());
+    when(questionSetPublicApi.claimOneForRetry(3)).thenReturn(Optional.empty());
 
     // when
     questionSetRetryScheduler.retryFailedQuestionSetGeneration();

--- a/src/test/java/kr/it/pullit/modules/questionset/service/QuestionSetServiceTest.java
+++ b/src/test/java/kr/it/pullit/modules/questionset/service/QuestionSetServiceTest.java
@@ -454,6 +454,10 @@ class QuestionSetServiceTest {
     @DisplayName("문제집을 기본 폴더로 이동시킨다")
     void relocateQuestionSetsToDefaultFolder() {
       Long memberId = 1L;
+      Long folderId = 77L;
+      CommonFolder sourceFolder =
+          CommonFolder.create(
+              "소스 폴더", CommonFolderType.QUESTION_SET, FolderScope.CUSTOM, 1, memberId);
       CommonFolder defaultFolder =
           CommonFolder.create(
               CommonFolder.DEFAULT_NAME,
@@ -464,13 +468,15 @@ class QuestionSetServiceTest {
       QuestionSet q1 = createQuestionSetWithId(1101L);
       QuestionSet q2 = createQuestionSetWithId(1102L);
 
+      when(commonFolderPublicApi.findFolderEntityById(memberId, folderId))
+          .thenReturn(Optional.of(sourceFolder));
       when(commonFolderPublicApi.getOrCreateDefaultQuestionSetFolder(memberId))
           .thenReturn(defaultFolder);
 
-      questionSetService.relocateQuestionSetsToDefaultFolder(memberId, 77L);
+      questionSetService.relocateQuestionSetsToDefaultFolder(memberId, folderId);
 
       verify(questionSetRepository)
-          .relocateAllByFolderIdToDefaultFolder(77L, defaultFolder.getId());
+          .relocateAllByFolderIdToDefaultFolder(folderId, defaultFolder.getId());
     }
 
     @Test

--- a/src/test/java/kr/it/pullit/modules/questionset/service/QuestionSetServiceTest.java
+++ b/src/test/java/kr/it/pullit/modules/questionset/service/QuestionSetServiceTest.java
@@ -466,12 +466,11 @@ class QuestionSetServiceTest {
 
       when(commonFolderPublicApi.getOrCreateDefaultQuestionSetFolder(memberId))
           .thenReturn(defaultFolder);
-      when(questionSetRepository.findAllByCommonFolderId(77L)).thenReturn(List.of(q1, q2));
 
       questionSetService.relocateQuestionSetsToDefaultFolder(memberId, 77L);
 
-      assertThat(q1.getCommonFolder()).isEqualTo(defaultFolder);
-      assertThat(q2.getCommonFolder()).isEqualTo(defaultFolder);
+      verify(questionSetRepository)
+          .relocateAllByFolderIdToDefaultFolder(77L, defaultFolder.getId());
     }
 
     @Test

--- a/src/test/java/kr/it/pullit/platform/migration/service/MigrationServiceIntegrationTest.java
+++ b/src/test/java/kr/it/pullit/platform/migration/service/MigrationServiceIntegrationTest.java
@@ -5,16 +5,19 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import kr.it.pullit.modules.learningsource.source.api.SourcePublicApi;
+import kr.it.pullit.modules.questionset.repository.QuestionSetRepositoryImpl;
 import kr.it.pullit.platform.migration.repository.MigrationHistoryRepository;
 import kr.it.pullit.platform.migration.repository.adapter.jpa.MigrationHistoryJpaRepository;
 import kr.it.pullit.support.annotation.IntegrationTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @IntegrationTest
 @DisplayName("MigrationService 통합 테스트")
+@Import(QuestionSetRepositoryImpl.class)
 class MigrationServiceIntegrationTest {
 
   private static final String MIGRATION_NAME = "SOURCE_STATUS_MIGRATION_V1";


### PR DESCRIPTION
<!-- PR 제목을 `이슈번호: 작업내용(명확히)`로 작성해주세요. -->

## PR 설명

비관적 락 (`SELECT ... FOR UPDATE`)은 특정 레코드를 조회하는 순간 데이터베이스 레벨에서 잠금을 설정합니다. 따라서 다른 트랜잭션은 해당 잠금이 해제될 때까지 접근할 수 없으므로, **정확히 하나의 워커만**이 작업을 처리할 수 있게 됩니다. 이는 이벤트 중복 발행과 같은 심각한 문제를 원천적으로 차단

낙관적 락은 충돌 시 예외 처리, 재시도, 백오프(Back-off) 로직이 추가로 필요합니다. 반면 비관적 락은 경쟁 발생 시 예외 대신 대기하거나, `SKIP LOCKED` 옵션을 통해 잠긴 행을 건너뛰므로 애플리케이션 로직이 단순해지고 예외 발생 빈도가 크게 줄어듬




<!--Release Notes:

- N/A _or_ Added/Fixed/Improved ...-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry processing so a single worker atomically claims and updates a failed question set to avoid duplicate work.

* **New Features**
  * Added a bulk relocation action to move all question sets from a folder into a default folder in one operation.

* **Chores**
  * Deployment now refreshes monitoring (Prometheus) after deploys.
  * Enabled virtual-thread support in runtime configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->