### PR TITLE
btsk-117: 소스 폴더 삭제 로직 스케줄링을 통해 s3 와 분리

### DIFF
--- a/src/main/java/kr/it/pullit/PullitApplication.java
+++ b/src/main/java/kr/it/pullit/PullitApplication.java
@@ -5,9 +5,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@EnableScheduling
 @SpringBootApplication
 @ConfigurationPropertiesScan
+@EnableScheduling
 public class PullitApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/kr/it/pullit/modules/learningsource/source/batch/SourceCleanupScheduler.java
+++ b/src/main/java/kr/it/pullit/modules/learningsource/source/batch/SourceCleanupScheduler.java
@@ -1,0 +1,22 @@
+package kr.it.pullit.modules.learningsource.source.batch;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+@ConditionalOnProperty(name = "app.scheduling.source-cleanup.enabled", havingValue = "true")
+public class SourceCleanupScheduler {
+
+  private final SourceCleanupService sourceCleanupService;
+
+  @Scheduled(cron = "${app.scheduling.source-cleanup.cron:0 0 4 * * ?}") // 매일 새벽 4시에 실행
+  public void runCleanup() {
+    log.info("Source 자동 정리 스케줄러를 실행합니다.");
+    sourceCleanupService.cleanupDeletedSources();
+  }
+}

--- a/src/main/java/kr/it/pullit/modules/learningsource/source/batch/SourceCleanupService.java
+++ b/src/main/java/kr/it/pullit/modules/learningsource/source/batch/SourceCleanupService.java
@@ -1,0 +1,48 @@
+package kr.it.pullit.modules.learningsource.source.batch;
+
+import java.util.List;
+import kr.it.pullit.modules.learningsource.source.domain.entity.Source;
+import kr.it.pullit.modules.learningsource.source.repository.SourceRepository;
+import kr.it.pullit.platform.storage.api.S3PublicApi;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SourceCleanupService {
+
+  private final SourceRepository sourceRepository;
+  private final S3PublicApi s3PublicApi;
+
+  @Transactional
+  public void cleanupDeletedSources() {
+    log.info("삭제 상태(DELETED)인 Source 정리를 시작합니다.");
+
+    List<Source> deletedSources = sourceRepository.findAllWithDeleted();
+    if (deletedSources.isEmpty()) {
+      log.info("정리할 Source가 없습니다.");
+      return;
+    }
+
+    int successCount = 0;
+    for (Source source : deletedSources) {
+      try {
+        s3PublicApi.deleteFile(source.getFilePath());
+        sourceRepository.delete(source);
+        successCount++;
+        log.info(
+            "Source(id:{}, path:{})가 S3와 DB에서 완전히 삭제되었습니다.", source.getId(), source.getFilePath());
+      } catch (Exception e) {
+        log.error(
+            "Source(id:{}, path:{}) 최종 삭제 처리 중 오류가 발생했습니다.",
+            source.getId(),
+            source.getFilePath(),
+            e);
+      }
+    }
+    log.info("Source 정리 작업을 완료했습니다. 총 {}개 중 {}개 성공.", deletedSources.size(), successCount);
+  }
+}

--- a/src/main/java/kr/it/pullit/modules/learningsource/source/constant/SourceStatus.java
+++ b/src/main/java/kr/it/pullit/modules/learningsource/source/constant/SourceStatus.java
@@ -4,5 +4,7 @@ public enum SourceStatus {
   UPLOADED, // 업로드 완료
   PROCESSING, // 처리 중
   READY, // 사용 가능
-  FAILED // 처리 실패
+  FAILED, // 처리 실패
+  NOT_EXIST, // 파일 S3에 존재하지 않음
+  DELETED // 삭제 요청됨
 }

--- a/src/main/java/kr/it/pullit/modules/learningsource/source/domain/entity/Source.java
+++ b/src/main/java/kr/it/pullit/modules/learningsource/source/domain/entity/Source.java
@@ -23,10 +23,15 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(
+    sql = "UPDATE source SET status = 'DELETED', updated_at = CURRENT_TIMESTAMP WHERE id = ?")
+@SQLRestriction("status <> 'DELETED'")
 public class Source extends BaseEntity {
 
   @ManyToMany(mappedBy = "sources")
@@ -116,6 +121,10 @@ public class Source extends BaseEntity {
 
   public void markAsFailed() {
     this.status = SourceStatus.FAILED;
+  }
+
+  public void markAsError() {
+    this.status = SourceStatus.NOT_EXIST;
   }
 
   @PreRemove

--- a/src/main/java/kr/it/pullit/modules/learningsource/source/exception/S3FileNotFoundForSourceException.java
+++ b/src/main/java/kr/it/pullit/modules/learningsource/source/exception/S3FileNotFoundForSourceException.java
@@ -1,0 +1,16 @@
+package kr.it.pullit.modules.learningsource.source.exception;
+
+import kr.it.pullit.shared.error.BusinessException;
+
+public class S3FileNotFoundForSourceException extends BusinessException {
+
+  private S3FileNotFoundForSourceException(Object... args) {
+    super(SourceErrorCode.S3_FILE_NOT_FOUND, args);
+  }
+
+  public static S3FileNotFoundForSourceException bySourceIdAndFilePath(
+      Long sourceId, String filePath) {
+    return new S3FileNotFoundForSourceException(
+        "S3에 파일이 존재하지 않습니다. (sourceId: %d, filePath: '%s')", sourceId, filePath);
+  }
+}

--- a/src/main/java/kr/it/pullit/modules/learningsource/source/exception/SourceErrorCode.java
+++ b/src/main/java/kr/it/pullit/modules/learningsource/source/exception/SourceErrorCode.java
@@ -10,7 +10,9 @@ import org.springframework.http.HttpStatus;
 public enum SourceErrorCode implements ErrorCode {
   SOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "SE_001", "소스를 찾을 수 없습니다. (%s: %s)"),
   SOURCE_FORBIDDEN(HttpStatus.FORBIDDEN, "SE_002", "사용자 %s는 해당 소스를 삭제할 권한이 없습니다."),
-  FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "SE_003", "파일 크기 제한을 초과했습니다.");
+  FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "SE_003", "파일 크기 제한을 초과했습니다."),
+  S3_FILE_NOT_FOUND(
+      HttpStatus.NOT_FOUND, "SE_004", "S3에 파일이 존재하지 않습니다. (sourceId: %d, filePath: '%s')");
 
   private final HttpStatus status;
   private final String code;

--- a/src/main/java/kr/it/pullit/modules/learningsource/source/repository/SourceRepository.java
+++ b/src/main/java/kr/it/pullit/modules/learningsource/source/repository/SourceRepository.java
@@ -24,4 +24,6 @@ public interface SourceRepository {
   void delete(Source source);
 
   List<Source> findByStatus(SourceStatus status);
+
+  List<Source> findAllWithDeleted();
 }

--- a/src/main/java/kr/it/pullit/modules/learningsource/source/repository/SourceRepositoryImpl.java
+++ b/src/main/java/kr/it/pullit/modules/learningsource/source/repository/SourceRepositoryImpl.java
@@ -58,4 +58,9 @@ public class SourceRepositoryImpl implements SourceRepository {
   public List<Source> findByStatus(SourceStatus status) {
     return sourceJpaRepository.findByStatus(status);
   }
+
+  @Override
+  public List<Source> findAllWithDeleted() {
+    return sourceJpaRepository.findAllWithDeleted();
+  }
 }

--- a/src/main/java/kr/it/pullit/modules/learningsource/source/repository/adapter/jpa/SourceJpaRepository.java
+++ b/src/main/java/kr/it/pullit/modules/learningsource/source/repository/adapter/jpa/SourceJpaRepository.java
@@ -13,11 +13,12 @@ public interface SourceJpaRepository extends JpaRepository<Source, Long> {
   List<Source> findByMemberIdOrderByCreatedAtDesc(Long memberId);
 
   @Query(
-      "SELECT s "
-          + "FROM Source s "
-          + "JOIN FETCH s.sourceFolder sf "
-          + "WHERE s.memberId = :memberId "
-          + "ORDER BY s.createdAt DESC")
+      """
+      SELECT s FROM Source s
+      JOIN FETCH s.sourceFolder
+      WHERE s.memberId = :memberId AND s.status <> 'DELETED'
+      ORDER BY s.createdAt DESC
+      """)
   List<Source> findSourcesByMemberIdWithDetails(@Param("memberId") Long memberId);
 
   Optional<Source> findByIdAndMemberId(Long id, Long memberId);
@@ -27,4 +28,14 @@ public interface SourceJpaRepository extends JpaRepository<Source, Long> {
   List<Source> findByStatus(SourceStatus status);
 
   Optional<Source> findByMemberIdAndFilePath(Long memberId, String filePath);
+
+  @Query(
+      value =
+          """
+                    SELECT *
+                    FROM source s
+                    WHERE s.status = 'DELETED'
+                 """,
+      nativeQuery = true)
+  List<Source> findAllWithDeleted();
 }

--- a/src/main/java/kr/it/pullit/modules/learningsource/source/service/SourceService.java
+++ b/src/main/java/kr/it/pullit/modules/learningsource/source/service/SourceService.java
@@ -3,13 +3,13 @@ package kr.it.pullit.modules.learningsource.source.service;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import kr.it.pullit.modules.learningsource.source.api.SourcePublicApi;
 import kr.it.pullit.modules.learningsource.source.constant.SourceStatus;
 import kr.it.pullit.modules.learningsource.source.domain.entity.Source;
 import kr.it.pullit.modules.learningsource.source.domain.entity.SourceCreationParam;
+import kr.it.pullit.modules.learningsource.source.exception.S3FileNotFoundForSourceException;
 import kr.it.pullit.modules.learningsource.source.exception.SourceFileSizeExceededException;
 import kr.it.pullit.modules.learningsource.source.exception.SourceNotFoundException;
 import kr.it.pullit.modules.learningsource.source.repository.SourceRepository;
@@ -27,6 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 
 @Service
 @RequiredArgsConstructor
@@ -64,9 +65,7 @@ public class SourceService implements SourcePublicApi {
   // TODO: 리팩토링 대상.
   @Override
   public void processUploadComplete(SourceUploadCompleteRequest request, Long memberId) {
-    if (!s3PublicApi.fileExists(request.getFilePath())) {
-      throw new IllegalArgumentException("S3에 해당 파일이 존재하지 않습니다.");
-    }
+    s3PublicApi.getFileMetadata(request.getFilePath());
     createOrUpdate(request, memberId);
   }
 
@@ -117,7 +116,12 @@ public class SourceService implements SourcePublicApi {
             .findByIdAndMemberId(sourceId, memberId)
             .orElseThrow(() -> SourceNotFoundException.byId(sourceId));
 
-    return s3PublicApi.downloadFileAsStream(source.getFilePath());
+    try {
+      return s3PublicApi.downloadFileAsStream(source.getFilePath());
+    } catch (NoSuchKeyException e) {
+      source.markAsError();
+      throw S3FileNotFoundForSourceException.bySourceIdAndFilePath(sourceId, source.getFilePath());
+    }
   }
 
   @Override
@@ -127,7 +131,12 @@ public class SourceService implements SourcePublicApi {
             .findByIdAndMemberId(sourceId, memberId)
             .orElseThrow(() -> SourceNotFoundException.byId(sourceId));
 
-    return s3PublicApi.downloadFileToTemp(source.getFilePath());
+    try {
+      return s3PublicApi.downloadFileToTemp(source.getFilePath());
+    } catch (NoSuchKeyException e) {
+      source.markAsError();
+      throw S3FileNotFoundForSourceException.bySourceIdAndFilePath(sourceId, source.getFilePath());
+    }
   }
 
   @Override
@@ -149,14 +158,9 @@ public class SourceService implements SourcePublicApi {
   public void deleteSource(Long sourceId, Long memberId) {
     Source source = getOrElseThrow(sourceId, memberId);
 
-    new HashSet<>(source.getQuestionSets())
-        .forEach(questionSet -> questionSet.removeSource(source));
-    source.getQuestionSets().clear();
-
+    // @SQLDelete 어노테이션에 의해 soft delete 처리된다.
+    // S3 파일 삭제는 별도의 배치 작업으로 처리한다.
     sourceRepository.delete(source);
-
-    String filePath = source.getFilePath();
-    deleteInS3(filePath);
   }
 
   @Transactional
@@ -231,13 +235,5 @@ public class SourceService implements SourcePublicApi {
     return sourceRepository
         .findByIdAndMemberId(sourceId, memberId)
         .orElseThrow(() -> SourceNotFoundException.byId(sourceId));
-  }
-
-  private void deleteInS3(String filePath) {
-    try {
-      s3PublicApi.deleteFile(filePath);
-    } catch (Exception e) {
-      log.warn("데이터베이스 삭제 후 S3 파일 삭제 실패: {}", filePath, e);
-    }
   }
 }

--- a/src/main/java/kr/it/pullit/platform/storage/api/S3PublicApi.java
+++ b/src/main/java/kr/it/pullit/platform/storage/api/S3PublicApi.java
@@ -4,11 +4,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import kr.it.pullit.platform.storage.s3.dto.PresignedUrlResponse;
+import kr.it.pullit.platform.storage.s3.dto.S3FileMetadata;
 
 public interface S3PublicApi {
 
   PresignedUrlResponse generateUploadUrl(
-      String fileName, String contentType, Long fileSize, Long ownerId);
+      String fileName, String contentType, Long fileSize, Long memberId);
 
   InputStream downloadFileAsStream(String filePath);
 
@@ -17,4 +18,6 @@ public interface S3PublicApi {
   boolean fileExists(String filePath);
 
   void deleteFile(String filePath);
+
+  S3FileMetadata getFileMetadata(String filePath);
 }

--- a/src/main/java/kr/it/pullit/platform/storage/s3/client/FileStorageClient.java
+++ b/src/main/java/kr/it/pullit/platform/storage/s3/client/FileStorageClient.java
@@ -3,6 +3,7 @@ package kr.it.pullit.platform.storage.s3.client;
 import java.io.InputStream;
 import java.net.URL;
 import java.time.Duration;
+import kr.it.pullit.platform.storage.s3.dto.S3FileMetadata;
 
 public interface FileStorageClient {
 
@@ -15,4 +16,6 @@ public interface FileStorageClient {
   String getFileUrl(String filePath);
 
   InputStream downloadFileAsStream(String filePath);
+
+  S3FileMetadata getFileMetadata(String filePath);
 }

--- a/src/main/java/kr/it/pullit/platform/storage/s3/client/S3FileStorageClientManagingClient.java
+++ b/src/main/java/kr/it/pullit/platform/storage/s3/client/S3FileStorageClientManagingClient.java
@@ -4,6 +4,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.time.Duration;
 import kr.it.pullit.platform.storage.core.S3StorageProps;
+import kr.it.pullit.platform.storage.s3.dto.S3FileMetadata;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
@@ -12,6 +13,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
@@ -101,6 +103,14 @@ public class S3FileStorageClientManagingClient implements FileStorageClient {
         }
       }
     }
+  }
+
+  @Override
+  public S3FileMetadata getFileMetadata(String filePath) {
+    HeadObjectRequest headRequest =
+        HeadObjectRequest.builder().bucket(s3StorageProps.getBucketName()).key(filePath).build();
+    HeadObjectResponse response = s3Client.headObject(headRequest);
+    return new S3FileMetadata(response.contentLength(), response.lastModified());
   }
 
   private S3Client createS3Client() {

--- a/src/main/java/kr/it/pullit/platform/storage/s3/dto/S3FileMetadata.java
+++ b/src/main/java/kr/it/pullit/platform/storage/s3/dto/S3FileMetadata.java
@@ -1,0 +1,10 @@
+package kr.it.pullit.platform.storage.s3.dto;
+
+import java.time.Instant;
+import lombok.Data;
+
+@Data
+public class S3FileMetadata {
+  private final long contentLength;
+  private final Instant lastModified;
+}

--- a/src/main/java/kr/it/pullit/platform/storage/s3/service/S3PresignedUrlService.java
+++ b/src/main/java/kr/it/pullit/platform/storage/s3/service/S3PresignedUrlService.java
@@ -12,6 +12,7 @@ import kr.it.pullit.platform.storage.core.FileValidation;
 import kr.it.pullit.platform.storage.core.S3StorageProps;
 import kr.it.pullit.platform.storage.s3.client.FileStorageClient;
 import kr.it.pullit.platform.storage.s3.dto.PresignedUrlResponse;
+import kr.it.pullit.platform.storage.s3.dto.S3FileMetadata;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -42,6 +43,11 @@ public class S3PresignedUrlService implements S3PublicApi {
   @Override
   public InputStream downloadFileAsStream(String filePath) {
     return fileStorageClient.downloadFileAsStream(filePath);
+  }
+
+  @Override
+  public S3FileMetadata getFileMetadata(String filePath) {
+    return fileStorageClient.getFileMetadata(filePath);
   }
 
   /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -168,6 +168,10 @@ cors:
 app:
   gemini:
     api-key: ${GEMINI_API_KEY:test}
+  scheduling:
+    source-cleanup:
+      enabled: true
+      cron: 0 0 4 * * ?
   storage:
     s3:
       bucket-name: "pullit-uploaded-files"

--- a/src/test/java/kr/it/pullit/modules/learningsource/source/service/SourceServiceIntegrationTest.java
+++ b/src/test/java/kr/it/pullit/modules/learningsource/source/service/SourceServiceIntegrationTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.BDDMockito.willDoNothing;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -144,33 +143,36 @@ class SourceServiceIntegrationTest {
       SourceUploadCompleteRequest request =
           new SourceUploadCompleteRequest(
               "upload-3", "learning-sources/missing.pdf", "missing.pdf", "application/pdf", 1024L);
+      Member member = MemberFixtures.basicUser();
 
-      given(s3PublicApi.fileExists(request.getFilePath())).willReturn(false);
+      var exception = software.amazon.awssdk.services.s3.model.NoSuchKeyException.builder().build();
+      given(s3PublicApi.getFileMetadata(request.getFilePath())).willThrow(exception);
+      given(memberPublicApi.findById(memberId)).willReturn(Optional.of(member));
 
       assertThatThrownBy(() -> sourceService.processUploadComplete(request, memberId))
-          .isInstanceOf(IllegalArgumentException.class)
-          .hasMessageContaining("S3에 해당 파일이 존재하지 않습니다.");
+          .isInstanceOf(software.amazon.awssdk.services.s3.model.NoSuchKeyException.class);
     }
   }
 
   @Test
-  @DisplayName("소스를 삭제하면 데이터와 S3 파일이 함께 정리된다")
-  void deleteSourceAlsoDeletesFileInS3() {
+  @DisplayName("소스를 삭제하면 soft delete 되어 상태만 변경된다")
+  void softDeleteSource() {
     Long memberId = 104L;
     SourceFolder folder = persistDefaultFolder(memberId);
     Source source =
         persistSource(memberId, "learning-sources/delete.pdf", folder, SourceStatus.READY);
     flushAndClear();
 
-    willDoNothing().given(s3PublicApi).deleteFile(source.getFilePath());
-
     sourceService.deleteSource(source.getId(), memberId);
     flushAndClear();
 
     Optional<Source> found = sourceRepository.findById(source.getId());
+    List<Source> deleted = sourceRepository.findAllWithDeleted();
 
     assertThat(found).isEmpty();
-    then(s3PublicApi).should().deleteFile(source.getFilePath());
+    assertThat(deleted).hasSize(1);
+    assertThat(deleted.getFirst().getStatus()).isEqualTo(SourceStatus.DELETED);
+    then(s3PublicApi).shouldHaveNoInteractions();
   }
 
   @Test

--- a/src/test/java/kr/it/pullit/modules/learningsource/source/service/SourceServiceTest.java
+++ b/src/test/java/kr/it/pullit/modules/learningsource/source/service/SourceServiceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -27,6 +26,7 @@ import kr.it.pullit.modules.member.api.MemberPublicApi;
 import kr.it.pullit.modules.member.exception.MemberNotFoundException;
 import kr.it.pullit.platform.storage.api.S3PublicApi;
 import kr.it.pullit.platform.storage.s3.dto.PresignedUrlResponse;
+import kr.it.pullit.platform.storage.s3.dto.S3FileMetadata;
 import kr.it.pullit.support.annotation.MockitoUnitTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -35,6 +35,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 
 @MockitoUnitTest
 @DisplayName("SourceService - 학습 소스 서비스 테스트")
@@ -137,7 +138,8 @@ class SourceServiceTest {
         new SourceUploadCompleteRequest(
             "upload-1", "learning-sources/new.pdf", "new.pdf", "application/pdf", 4096L);
 
-    given(s3PublicApi.fileExists(request.getFilePath())).willReturn(true);
+    given(s3PublicApi.getFileMetadata(request.getFilePath()))
+        .willReturn(new S3FileMetadata(4096L, null));
     given(sourceRepository.findByMemberIdAndFilePath(memberId, request.getFilePath()))
         .willReturn(Optional.empty());
     given(memberPublicApi.findById(memberId))
@@ -170,7 +172,8 @@ class SourceServiceTest {
         new SourceUploadCompleteRequest(
             "upload-2", "learning-sources/exist.pdf", "updated.pdf", "application/pdf", 8192L);
 
-    given(s3PublicApi.fileExists(request.getFilePath())).willReturn(true);
+    given(s3PublicApi.getFileMetadata(request.getFilePath()))
+        .willReturn(new S3FileMetadata(8192L, null));
     given(sourceRepository.findByMemberIdAndFilePath(memberId, request.getFilePath()))
         .willReturn(Optional.of(existing));
     given(sourceRepository.save(existing)).willReturn(existing);
@@ -191,12 +194,11 @@ class SourceServiceTest {
     SourceUploadCompleteRequest request =
         new SourceUploadCompleteRequest(
             "upload-3", "learning-sources/missing.pdf", "missing.pdf", "application/pdf", 1024L);
-
-    given(s3PublicApi.fileExists(request.getFilePath())).willReturn(false);
+    var exception = NoSuchKeyException.builder().build();
+    given(s3PublicApi.getFileMetadata(request.getFilePath())).willThrow(exception);
 
     assertThatThrownBy(() -> sourceService.processUploadComplete(request, memberId))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("S3에 해당 파일이 존재하지 않습니다.");
+        .isInstanceOf(NoSuchKeyException.class);
 
     verifyNoInteractions(memberPublicApi, sourceFolderPublicApi);
   }
@@ -213,7 +215,8 @@ class SourceServiceTest {
             "application/pdf",
             512L);
 
-    given(s3PublicApi.fileExists(request.getFilePath())).willReturn(true);
+    given(s3PublicApi.getFileMetadata(request.getFilePath()))
+        .willReturn(new S3FileMetadata(512L, null));
     given(sourceRepository.findByMemberIdAndFilePath(memberId, request.getFilePath()))
         .willReturn(Optional.empty());
     given(memberPublicApi.findById(memberId)).willReturn(Optional.empty());
@@ -273,7 +276,7 @@ class SourceServiceTest {
   }
 
   @Test
-  @DisplayName("성공 - 소스를 삭제하면 저장소와 S3에서 함께 제거된다")
+  @DisplayName("성공 - 소스를 삭제하면 soft delete 되어 상태가 변경된다")
   void deleteSource() {
     Long memberId = 23L;
     Source source = createSource(memberId, "learning-sources/delete.pdf", SourceStatus.READY);
@@ -282,21 +285,7 @@ class SourceServiceTest {
     sourceService.deleteSource(7L, memberId);
 
     verify(sourceRepository).delete(source);
-    verify(s3PublicApi).deleteFile("learning-sources/delete.pdf");
-  }
-
-  @Test
-  @DisplayName("성공 - S3 삭제가 실패해도 예외를 전파하지 않는다")
-  void deleteSourceWhenS3Fails() {
-    Long memberId = 25L;
-    Source source = createSource(memberId, "learning-sources/fail.pdf", SourceStatus.READY);
-    given(sourceRepository.findByIdAndMemberId(8L, memberId)).willReturn(Optional.of(source));
-    doThrow(new RuntimeException("boom")).when(s3PublicApi).deleteFile("learning-sources/fail.pdf");
-
-    sourceService.deleteSource(8L, memberId);
-
-    verify(sourceRepository).delete(source);
-    verify(s3PublicApi).deleteFile("learning-sources/fail.pdf");
+    verify(s3PublicApi, never()).deleteFile(any());
   }
 
   @Test


### PR DESCRIPTION
<!-- PR 제목을 `이슈번호: 작업내용(명확히)`로 작성해주세요. -->

## PR 설명

소스 폴더 삭제 로직 디비에만 신경쓰게 격리 . 스케줄링을 통해 s3 와 분리

<!--Release Notes:

- N/A _or_ Added/Fixed/Improved ...-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automatic daily cleanup of deleted sources at 4:00 AM.
  * Implemented soft-delete functionality for sources to maintain data integrity.

* **Bug Fixes**
  * Enhanced error handling and reporting for missing storage files with improved diagnostic messages.
  * Added file metadata validation to prevent processing of inaccessible files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->