### PR TITLE
btsk-118: 스케줄링 재시도 로직 및 로그 및 낙관적 락 에러 로그 경고로 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ htmlReport
 # 로컬 개발용 SSL 인증서 개인 키 제외
 nginx/certs/*.key
 nginx/certs/*.crt
+nginx/certs/*.pem

--- a/build.gradle
+++ b/build.gradle
@@ -160,10 +160,10 @@ dependencies {
 
     testImplementation 'org.mockito:mockito-inline:5.2.0'
     testImplementation 'com.squareup.okhttp3:okhttp-sse'
+    // spring retry
     implementation 'org.springframework.retry:spring-retry'
     // batch
     implementation 'org.springframework.boot:spring-boot-starter-batch'
-    // spring scheduler lock
 }
 
 // 의존성 버전 관리 (BOM 사용)

--- a/build.gradle
+++ b/build.gradle
@@ -160,6 +160,10 @@ dependencies {
 
     testImplementation 'org.mockito:mockito-inline:5.2.0'
     testImplementation 'com.squareup.okhttp3:okhttp-sse'
+    implementation 'org.springframework.retry:spring-retry'
+    // batch
+    implementation 'org.springframework.boot:spring-boot-starter-batch'
+    // spring scheduler lock
 }
 
 // 의존성 버전 관리 (BOM 사용)

--- a/docker-compose.qa.yml
+++ b/docker-compose.qa.yml
@@ -77,6 +77,12 @@ services:
       - pullit-qa-network
     image: ${DOCKER_IMAGE_BLUE}
     container_name: pullit-qa-worker-blue
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/actuator/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 90s
     environment:
       <<: *pullit-common-env
       SPRING_PROFILES_ACTIVE: qa,worker
@@ -94,6 +100,12 @@ services:
       - pullit-qa-network
     image: ${DOCKER_IMAGE_GREEN}
     container_name: pullit-qa-worker-green
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/actuator/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 90s
     environment:
       <<: *pullit-common-env
       SPRING_PROFILES_ACTIVE: qa,worker

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -2,8 +2,8 @@ server {
     listen 443 ssl;
     server_name localhost;
 
-    ssl_certificate /etc/nginx/certs/localhost.crt;
-    ssl_certificate_key /etc/nginx/certs/localhost.key;
+    ssl_certificate /etc/nginx/certs/localhost.pem;
+    ssl_certificate_key /etc/nginx/certs/localhost-key.pem;
 
     # SSL Settings
     ssl_protocols TLSv1.2 TLSv1.3;

--- a/src/main/java/kr/it/pullit/PullitApplication.java
+++ b/src/main/java/kr/it/pullit/PullitApplication.java
@@ -3,11 +3,13 @@ package kr.it.pullit;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
 @EnableScheduling
+@EnableRetry
 public class PullitApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/kr/it/pullit/modules/learningsource/source/batch/SourceCleanupScheduler.java
+++ b/src/main/java/kr/it/pullit/modules/learningsource/source/batch/SourceCleanupScheduler.java
@@ -2,7 +2,11 @@ package kr.it.pullit.modules.learningsource.source.batch;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -15,6 +19,12 @@ public class SourceCleanupScheduler {
   private final SourceCleanupService sourceCleanupService;
 
   @Scheduled(cron = "${app.scheduling.source-cleanup.cron:0 0 4 * * ?}") // 매일 새벽 4시에 실행
+  @SchedulerLock(name = "runSourceCleanup", lockAtMostFor = "50m", lockAtLeastFor = "10m")
+  @Retryable(
+      value = {ObjectOptimisticLockingFailureException.class},
+      maxAttempts = 3,
+      backoff = @Backoff(delay = 1000),
+      listeners = "optimisticLockingRetryListener")
   public void runCleanup() {
     log.info("Source 자동 정리 스케줄러를 실행합니다.");
     sourceCleanupService.cleanupDeletedSources();

--- a/src/main/java/kr/it/pullit/modules/learningsource/source/batch/SourceCleanupScheduler.java
+++ b/src/main/java/kr/it/pullit/modules/learningsource/source/batch/SourceCleanupScheduler.java
@@ -1,12 +1,11 @@
 package kr.it.pullit.modules.learningsource.source.batch;
 
+import kr.it.pullit.shared.retry.RetryOnOptimisticLock;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -20,11 +19,7 @@ public class SourceCleanupScheduler {
 
   @Scheduled(cron = "${app.scheduling.source-cleanup.cron:0 0 4 * * ?}") // 매일 새벽 4시에 실행
   @SchedulerLock(name = "runSourceCleanup", lockAtMostFor = "50m", lockAtLeastFor = "10m")
-  @Retryable(
-      value = {ObjectOptimisticLockingFailureException.class},
-      maxAttempts = 3,
-      backoff = @Backoff(delay = 1000),
-      listeners = "optimisticLockingRetryListener")
+  @RetryOnOptimisticLock(backoff = @Backoff(delay = 1000))
   public void runCleanup() {
     log.info("Source 자동 정리 스케줄러를 실행합니다.");
     sourceCleanupService.cleanupDeletedSources();

--- a/src/main/java/kr/it/pullit/modules/learningsource/source/exception/S3FileNotFoundForSourceException.java
+++ b/src/main/java/kr/it/pullit/modules/learningsource/source/exception/S3FileNotFoundForSourceException.java
@@ -10,7 +10,6 @@ public class S3FileNotFoundForSourceException extends BusinessException {
 
   public static S3FileNotFoundForSourceException bySourceIdAndFilePath(
       Long sourceId, String filePath) {
-    return new S3FileNotFoundForSourceException(
-        "S3에 파일이 존재하지 않습니다. (sourceId: %d, filePath: '%s')", sourceId, filePath);
+    return new S3FileNotFoundForSourceException(sourceId, filePath);
   }
 }

--- a/src/main/java/kr/it/pullit/modules/learningsource/source/service/SourceService.java
+++ b/src/main/java/kr/it/pullit/modules/learningsource/source/service/SourceService.java
@@ -154,12 +154,14 @@ public class SourceService implements SourcePublicApi {
     return sourceRepository.findByIdIn(ids);
   }
 
+  /**
+   * 소스 삭제 시 문제집과의 연관 관계를 자동으로 제거해준다. @SQLDelete 어노테이션에 의해 soft delete 처리된다. S3 파일 삭제는 별도의 배치 작업으로
+   * 처리한다. Source 엔티티의 @PreRemove 콜백이 QuestionSet과의 연관 관계를 자동으로 제거해준다.
+   */
   @Override
   public void deleteSource(Long sourceId, Long memberId) {
     Source source = getOrElseThrow(sourceId, memberId);
 
-    // @SQLDelete 어노테이션에 의해 soft delete 처리된다.
-    // S3 파일 삭제는 별도의 배치 작업으로 처리한다.
     sourceRepository.delete(source);
   }
 

--- a/src/main/java/kr/it/pullit/modules/projection/learnstats/batch/LearnStatsBatchScheduler.java
+++ b/src/main/java/kr/it/pullit/modules/projection/learnstats/batch/LearnStatsBatchScheduler.java
@@ -4,15 +4,14 @@ import kr.it.pullit.modules.member.api.MemberPublicApi;
 import kr.it.pullit.modules.member.domain.entity.Member;
 import kr.it.pullit.modules.projection.learnstats.api.LearnStatsEventPublicApi;
 import kr.it.pullit.modules.projection.learnstats.api.LearnStatsRecalibrationPublicApi;
+import kr.it.pullit.shared.retry.RetryOnOptimisticLock;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -31,11 +30,7 @@ public class LearnStatsBatchScheduler {
       name = "triggerWeeklyResetAndRecalibration",
       lockAtMostFor = "50m",
       lockAtLeastFor = "10m")
-  @Retryable(
-      value = {ObjectOptimisticLockingFailureException.class},
-      maxAttempts = 3,
-      backoff = @Backoff(delay = 5000),
-      listeners = "optimisticLockingRetryListener")
+  @RetryOnOptimisticLock(backoff = @Backoff(delay = 5000))
   public void triggerWeeklyResetAndRecalibration() {
     log.info("주간 학습 통계 초기화 및 보정 작업을 시작합니다.");
 

--- a/src/main/java/kr/it/pullit/modules/projection/learnstats/batch/LearnStatsBatchScheduler.java
+++ b/src/main/java/kr/it/pullit/modules/projection/learnstats/batch/LearnStatsBatchScheduler.java
@@ -10,6 +10,9 @@ import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -28,6 +31,11 @@ public class LearnStatsBatchScheduler {
       name = "triggerWeeklyResetAndRecalibration",
       lockAtMostFor = "50m",
       lockAtLeastFor = "10m")
+  @Retryable(
+      value = {ObjectOptimisticLockingFailureException.class},
+      maxAttempts = 3,
+      backoff = @Backoff(delay = 5000),
+      listeners = "optimisticLockingRetryListener")
   public void triggerWeeklyResetAndRecalibration() {
     log.info("주간 학습 통계 초기화 및 보정 작업을 시작합니다.");
 

--- a/src/main/java/kr/it/pullit/modules/projection/learnstats/scheduler/LearnStatsScheduler.java
+++ b/src/main/java/kr/it/pullit/modules/projection/learnstats/scheduler/LearnStatsScheduler.java
@@ -3,6 +3,9 @@ package kr.it.pullit.modules.projection.learnstats.scheduler;
 import kr.it.pullit.modules.projection.learnstats.service.LearnStatsValidationService;
 import lombok.RequiredArgsConstructor;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -17,6 +20,11 @@ public class LearnStatsScheduler {
       name = "validateConsecutiveLearning",
       lockAtMostFor = "23h",
       lockAtLeastFor = "10m")
+  @Retryable(
+      value = {ObjectOptimisticLockingFailureException.class},
+      maxAttempts = 3,
+      backoff = @Backoff(delay = 5000),
+      listeners = "optimisticLockingRetryListener")
   public void validateConsecutiveLearning() {
     learnStatsValidationService.validateAllMembersConsecutiveLearning();
   }

--- a/src/main/java/kr/it/pullit/modules/projection/learnstats/scheduler/LearnStatsScheduler.java
+++ b/src/main/java/kr/it/pullit/modules/projection/learnstats/scheduler/LearnStatsScheduler.java
@@ -1,11 +1,10 @@
 package kr.it.pullit.modules.projection.learnstats.scheduler;
 
 import kr.it.pullit.modules.projection.learnstats.service.LearnStatsValidationService;
+import kr.it.pullit.shared.retry.RetryOnOptimisticLock;
 import lombok.RequiredArgsConstructor;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
-import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -20,11 +19,7 @@ public class LearnStatsScheduler {
       name = "validateConsecutiveLearning",
       lockAtMostFor = "23h",
       lockAtLeastFor = "10m")
-  @Retryable(
-      value = {ObjectOptimisticLockingFailureException.class},
-      maxAttempts = 3,
-      backoff = @Backoff(delay = 5000),
-      listeners = "optimisticLockingRetryListener")
+  @RetryOnOptimisticLock(backoff = @Backoff(delay = 5000))
   public void validateConsecutiveLearning() {
     learnStatsValidationService.validateAllMembersConsecutiveLearning();
   }

--- a/src/main/java/kr/it/pullit/modules/projection/outbox/relay/OutboxEventRelay.java
+++ b/src/main/java/kr/it/pullit/modules/projection/outbox/relay/OutboxEventRelay.java
@@ -6,12 +6,11 @@ import kr.it.pullit.modules.projection.outbox.domain.OutboxEvent;
 import kr.it.pullit.modules.projection.outbox.domain.ProcessedEvent;
 import kr.it.pullit.modules.projection.outbox.repository.OutboxEventJpaRepository;
 import kr.it.pullit.modules.projection.outbox.repository.ProcessedEventRepository;
+import kr.it.pullit.shared.retry.RetryOnOptimisticLock;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
-import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -27,12 +26,8 @@ public class OutboxEventRelay {
   private final TransactionTemplate transactionTemplate;
 
   @Scheduled(fixedDelay = 1000)
-  @SchedulerLock(name = "relayOutboxEvents", lockAtMostFor = "900ms", lockAtLeastFor = "100ms")
-  @Retryable(
-      value = {ObjectOptimisticLockingFailureException.class},
-      maxAttempts = 3,
-      backoff = @Backoff(delay = 500),
-      listeners = "optimisticLockingRetryListener")
+  @SchedulerLock(name = "relayOutboxEvents", lockAtMostFor = "5s", lockAtLeastFor = "100ms")
+  @RetryOnOptimisticLock(backoff = @Backoff(delay = 500))
   public void relayOutboxEvents() {
     List<OutboxEvent> events = outboxEventRepository.findTop100ByOrderByCreatedAtAsc();
 

--- a/src/main/java/kr/it/pullit/modules/projection/outbox/relay/OutboxEventRelay.java
+++ b/src/main/java/kr/it/pullit/modules/projection/outbox/relay/OutboxEventRelay.java
@@ -9,6 +9,9 @@ import kr.it.pullit.modules.projection.outbox.repository.ProcessedEventRepositor
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -25,6 +28,11 @@ public class OutboxEventRelay {
 
   @Scheduled(fixedDelay = 1000)
   @SchedulerLock(name = "relayOutboxEvents", lockAtMostFor = "900ms", lockAtLeastFor = "100ms")
+  @Retryable(
+      value = {ObjectOptimisticLockingFailureException.class},
+      maxAttempts = 3,
+      backoff = @Backoff(delay = 500),
+      listeners = "optimisticLockingRetryListener")
   public void relayOutboxEvents() {
     List<OutboxEvent> events = outboxEventRepository.findTop100ByOrderByCreatedAtAsc();
 

--- a/src/main/java/kr/it/pullit/modules/questionset/api/QuestionSetPublicApi.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/api/QuestionSetPublicApi.java
@@ -20,6 +20,8 @@ public interface QuestionSetPublicApi {
 
   void markAsFailed(Long questionSetId);
 
+  void markAsUnprocessable(Long questionSetId);
+
   void update(Long questionSetId, QuestionSetUpdateRequestDto request, Long memberId);
 
   void updateAndMarkAsComplete(
@@ -30,8 +32,6 @@ public interface QuestionSetPublicApi {
   void deleteAllByFolderId(Long folderId);
 
   void relocateQuestionSetsToDefaultFolder(Long memberId, Long folderId);
-
-  List<QuestionSet> findAllByFolderId(Long folderId);
 
   List<QuestionSet> findStalePending(LocalDateTime threshold);
 
@@ -58,5 +58,5 @@ public interface QuestionSetPublicApi {
 
   long countByMemberId(Long memberId);
 
-  QuestionSetResponse getQuestionSetWhenHaveNoQuestionsYet(Long id, Long memberId);
+  QuestionSetResponse getQuestionSetWhenHaveNoQuestionsYet(Long questionSetId, Long ownerId);
 }

--- a/src/main/java/kr/it/pullit/modules/questionset/client/GeminiClient.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/client/GeminiClient.java
@@ -52,7 +52,7 @@ public class GeminiClient implements LlmClient {
     } catch (IOException e) {
       throw LlmResponseParseException.create(e);
     } catch (Exception e) {
-      throw LlmException.withCause(e);
+      throw LlmException.ofTemporary(e);
     }
   }
 
@@ -71,8 +71,12 @@ public class GeminiClient implements LlmClient {
               }
               var knownReason = finishReason.knownEnum();
               if (knownReason != Known.STOP && knownReason != Known.FINISH_REASON_UNSPECIFIED) {
-                throw LlmException.generationFailed(
-                    "AI 모델이 비정상적으로 응답 생성을 중단했습니다. (사유: " + response.finishReason() + ")");
+                String reason =
+                    "AI 모델이 비정상적으로 응답 생성을 중단했습니다. (사유: " + response.finishReason() + ")";
+                if (finishReason.toString().contains("exceeds the supported page limit")) {
+                  throw LlmException.ofPermanent(reason);
+                }
+                throw LlmException.ofTemporary(reason);
               }
             })
         .map(GenerateContentResponse::text)

--- a/src/main/java/kr/it/pullit/modules/questionset/client/GeminiClient.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/client/GeminiClient.java
@@ -52,6 +52,10 @@ public class GeminiClient implements LlmClient {
     } catch (IOException e) {
       throw LlmResponseParseException.create(e);
     } catch (Exception e) {
+      String message = e.getMessage();
+      if (message != null && message.contains("exceeds the supported page limit")) {
+        throw LlmException.permanent(e);
+      }
       throw LlmException.ofTemporary(e);
     }
   }
@@ -70,14 +74,20 @@ public class GeminiClient implements LlmClient {
                 return;
               }
               var knownReason = finishReason.knownEnum();
-              if (knownReason != Known.STOP && knownReason != Known.FINISH_REASON_UNSPECIFIED) {
-                String reason =
-                    "AI 모델이 비정상적으로 응답 생성을 중단했습니다. (사유: " + response.finishReason() + ")";
-                if (finishReason.toString().contains("exceeds the supported page limit")) {
-                  throw LlmException.ofPermanent(reason);
-                }
-                throw LlmException.ofTemporary(reason);
+              if (knownReason == Known.STOP || knownReason == Known.FINISH_REASON_UNSPECIFIED) {
+                return;
               }
+
+              String reasonText =
+                  "AI 모델이 비정상적으로 응답 생성을 중단했습니다. (사유: " + response.finishReason() + ")";
+
+              if (knownReason == Known.MAX_TOKENS
+                  || knownReason == Known.SAFETY
+                  || knownReason == Known.RECITATION) {
+                throw LlmException.permanent(reasonText);
+              }
+
+              throw LlmException.ofTemporary(reasonText);
             })
         .map(GenerateContentResponse::text)
         .filter(text -> text != null && !text.isEmpty())

--- a/src/main/java/kr/it/pullit/modules/questionset/client/dto/request/GeminiRequest.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/client/dto/request/GeminiRequest.java
@@ -53,7 +53,7 @@ public record GeminiRequest(String model, Content content, GenerateContentConfig
       try {
         parts.add(Part.fromBytes(Files.readAllBytes(fileData), "application/pdf"));
       } catch (IOException e) {
-        throw LlmException.withCause(e);
+        throw LlmException.from(e);
       }
     }
     return parts;

--- a/src/main/java/kr/it/pullit/modules/questionset/client/exception/LlmErrorType.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/client/exception/LlmErrorType.java
@@ -1,0 +1,6 @@
+package kr.it.pullit.modules.questionset.client.exception;
+
+public enum LlmErrorType {
+  PERMANENT, // 예: 페이지 제한 초과
+  TEMPORARY // 예: 요청량 제한, 네트워크 문제
+}

--- a/src/main/java/kr/it/pullit/modules/questionset/client/exception/LlmException.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/client/exception/LlmException.java
@@ -1,22 +1,42 @@
 package kr.it.pullit.modules.questionset.client.exception;
 
 import kr.it.pullit.shared.error.BusinessException;
+import lombok.Getter;
 
+@Getter
 public class LlmException extends BusinessException {
 
-  private LlmException(Throwable cause, Object... args) {
+  private final LlmErrorType errorType;
+
+  private LlmException(LlmErrorType errorType, Throwable cause, Object... args) {
     super(LlmErrorCode.LLM_GENERATION_FAILED, cause, args);
+    this.errorType = errorType;
   }
 
-  private LlmException(Object... args) {
+  private LlmException(LlmErrorType errorType, Object... args) {
     super(LlmErrorCode.LLM_GENERATION_FAILED, args);
+    this.errorType = errorType;
   }
 
-  public static LlmException generationFailed(String reason) {
-    return new LlmException(reason);
+  public static LlmException ofTemporary(String reason) {
+    return new LlmException(LlmErrorType.TEMPORARY, reason);
   }
 
-  public static LlmException withCause(Throwable cause) {
-    return new LlmException(cause, cause.getMessage());
+  public static LlmException ofTemporary(Throwable cause) {
+    return new LlmException(LlmErrorType.TEMPORARY, cause, cause.getMessage());
+  }
+
+  /**
+   * 다른 예외(cause)를 감싸서 일시적인 LlmException으로 변환합니다.
+   *
+   * @param cause 근본 원인이 되는 예외
+   * @return 원인을 포함하는 새로운 LlmException
+   */
+  public static LlmException from(Throwable cause) {
+    return ofTemporary(cause);
+  }
+
+  public static LlmException ofPermanent(String reason) {
+    return new LlmException(LlmErrorType.PERMANENT, reason);
   }
 }

--- a/src/main/java/kr/it/pullit/modules/questionset/client/exception/LlmException.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/client/exception/LlmException.java
@@ -33,4 +33,12 @@ public class LlmException extends BusinessException {
   public static LlmException ofPermanent(String reason) {
     return new LlmException(LlmErrorType.PERMANENT, reason);
   }
+
+  public static LlmException permanent(String reason) {
+    return new LlmException(LlmErrorType.PERMANENT, reason);
+  }
+
+  public static LlmException permanent(Throwable cause) {
+    return new LlmException(LlmErrorType.PERMANENT, cause, cause.getMessage());
+  }
 }

--- a/src/main/java/kr/it/pullit/modules/questionset/client/exception/LlmException.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/client/exception/LlmException.java
@@ -26,12 +26,6 @@ public class LlmException extends BusinessException {
     return new LlmException(LlmErrorType.TEMPORARY, cause, cause.getMessage());
   }
 
-  /**
-   * 다른 예외(cause)를 감싸서 일시적인 LlmException으로 변환합니다.
-   *
-   * @param cause 근본 원인이 되는 예외
-   * @return 원인을 포함하는 새로운 LlmException
-   */
   public static LlmException from(Throwable cause) {
     return ofTemporary(cause);
   }

--- a/src/main/java/kr/it/pullit/modules/questionset/domain/entity/QuestionSet.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/domain/entity/QuestionSet.java
@@ -35,6 +35,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
@@ -71,6 +72,7 @@ public class QuestionSet extends BaseEntity {
       name = "question_set_source",
       joinColumns = @JoinColumn(name = "question_set_id"),
       inverseJoinColumns = @JoinColumn(name = "source_id"))
+  @BatchSize(size = 100)
   private Set<Source> sources = new HashSet<>();
 
   // TODO: 리팩토링 대상 타이틀 정책이 빈약함.

--- a/src/main/java/kr/it/pullit/modules/questionset/domain/entity/QuestionSet.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/domain/entity/QuestionSet.java
@@ -46,6 +46,8 @@ import org.hibernate.annotations.SQLRestriction;
 @SQLRestriction("deleted_at IS NULL")
 public class QuestionSet extends BaseEntity {
 
+  public static final int MAX_RETRY_COUNT = 3;
+
   @OneToMany(mappedBy = "questionSet", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<Question> questions = new ArrayList<>();
 
@@ -188,6 +190,10 @@ public class QuestionSet extends BaseEntity {
     this.status = QuestionSetStatus.FAILED;
   }
 
+  public void markAsUnprocessable() {
+    this.status = QuestionSetStatus.UNPROCESSABLE;
+  }
+
   public void updateTitle(String title) {
     this.title = title;
   }
@@ -199,5 +205,9 @@ public class QuestionSet extends BaseEntity {
   public void retry() {
     this.status = QuestionSetStatus.PENDING;
     this.retryCount++;
+  }
+
+  public boolean hasExhaustedRetries() {
+    return this.retryCount >= MAX_RETRY_COUNT;
   }
 }

--- a/src/main/java/kr/it/pullit/modules/questionset/enums/QuestionSetStatus.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/enums/QuestionSetStatus.java
@@ -4,5 +4,6 @@ package kr.it.pullit.modules.questionset.enums;
 public enum QuestionSetStatus {
   PENDING,
   COMPLETE,
-  FAILED
+  FAILED,
+  UNPROCESSABLE
 }

--- a/src/main/java/kr/it/pullit/modules/questionset/event/QuestionGenerationFailureHandler.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/event/QuestionGenerationFailureHandler.java
@@ -1,0 +1,57 @@
+package kr.it.pullit.modules.questionset.event;
+
+import java.util.Optional;
+import kr.it.pullit.modules.questionset.api.QuestionSetPublicApi;
+import kr.it.pullit.modules.questionset.client.exception.LlmException;
+import kr.it.pullit.modules.questionset.domain.entity.QuestionSet;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class QuestionGenerationFailureHandler {
+
+  private final QuestionSetPublicApi questionSetPublicApi;
+
+  public void handle(QuestionSetCreatedEvent event, Exception e) {
+    log.error("문제 생성 중 오류 발생. QuestionSet ID: {}", event.questionSetId(), e);
+
+    if (isPermanentLlmError(e)) {
+      handlePermanentFailure(event.questionSetId(), "페이지 한도 초과");
+      return;
+    }
+    handleTemporaryFailure(event);
+  }
+
+  private boolean isPermanentLlmError(Exception e) {
+    return e instanceof LlmException && e.getMessage().contains("exceeds the supported page limit");
+  }
+
+  private void handlePermanentFailure(Long questionSetId, String reason) {
+    questionSetPublicApi.markAsUnprocessable(questionSetId);
+    log.warn(
+        "문제집 ID {}는 처리 불가능한(UNPROCESSABLE) 상태로 변경되었습니다. (사유: {})",
+        questionSetId,
+        reason);
+  }
+
+  private void handleTemporaryFailure(QuestionSetCreatedEvent event) {
+    Optional<QuestionSet> questionSetOpt =
+        questionSetPublicApi.findEntityByIdAndMemberId(event.questionSetId(), event.ownerId());
+
+    if (questionSetOpt.isEmpty()) {
+      log.error("실패 처리 중 문제집을 찾을 수 없습니다. QuestionSet ID: {}", event.questionSetId());
+      return;
+    }
+
+    QuestionSet questionSet = questionSetOpt.get();
+    if (questionSet.hasExhaustedRetries()) {
+      handlePermanentFailure(
+          event.questionSetId(), "최대 재시도 횟수(" + QuestionSet.MAX_RETRY_COUNT + ") 도달");
+    } else {
+      questionSetPublicApi.markAsFailed(event.questionSetId());
+    }
+  }
+}

--- a/src/main/java/kr/it/pullit/modules/questionset/event/QuestionGenerationFailureHandler.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/event/QuestionGenerationFailureHandler.java
@@ -2,6 +2,7 @@ package kr.it.pullit.modules.questionset.event;
 
 import java.util.Optional;
 import kr.it.pullit.modules.questionset.api.QuestionSetPublicApi;
+import kr.it.pullit.modules.questionset.client.exception.LlmErrorType;
 import kr.it.pullit.modules.questionset.client.exception.LlmException;
 import kr.it.pullit.modules.questionset.domain.entity.QuestionSet;
 import lombok.RequiredArgsConstructor;
@@ -19,14 +20,14 @@ public class QuestionGenerationFailureHandler {
     log.error("문제 생성 중 오류 발생. QuestionSet ID: {}", event.questionSetId(), e);
 
     if (isPermanentLlmError(e)) {
-      handlePermanentFailure(event.questionSetId(), "페이지 한도 초과");
+      handlePermanentFailure(event.questionSetId(), "페이지 한도 초과와 같은 영구적인 LLM 오류");
       return;
     }
     handleTemporaryFailure(event);
   }
 
   private boolean isPermanentLlmError(Exception e) {
-    return e instanceof LlmException && e.getMessage().contains("exceeds the supported page limit");
+    return e instanceof LlmException llmEx && llmEx.getErrorType() == LlmErrorType.PERMANENT;
   }
 
   private void handlePermanentFailure(Long questionSetId, String reason) {

--- a/src/main/java/kr/it/pullit/modules/questionset/event/QuestionGenerationFailureHandler.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/event/QuestionGenerationFailureHandler.java
@@ -31,10 +31,7 @@ public class QuestionGenerationFailureHandler {
 
   private void handlePermanentFailure(Long questionSetId, String reason) {
     questionSetPublicApi.markAsUnprocessable(questionSetId);
-    log.warn(
-        "문제집 ID {}는 처리 불가능한(UNPROCESSABLE) 상태로 변경되었습니다. (사유: {})",
-        questionSetId,
-        reason);
+    log.warn("문제집 ID {}는 처리 불가능한(UNPROCESSABLE) 상태로 변경되었습니다. (사유: {})", questionSetId, reason);
   }
 
   private void handleTemporaryFailure(QuestionSetCreatedEvent event) {

--- a/src/main/java/kr/it/pullit/modules/questionset/event/QuestionGenerationWorker.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/event/QuestionGenerationWorker.java
@@ -9,7 +9,6 @@ import kr.it.pullit.modules.questionset.domain.entity.Question;
 import kr.it.pullit.modules.questionset.domain.entity.QuestionGenerationRequest;
 import kr.it.pullit.modules.questionset.domain.entity.QuestionGenerationSpecification;
 import kr.it.pullit.modules.questionset.domain.entity.QuestionSet;
-import kr.it.pullit.modules.questionset.client.exception.LlmException;
 import kr.it.pullit.modules.questionset.service.SourceValidator;
 import kr.it.pullit.modules.questionset.service.creationstrategy.QuestionCreationStrategyFactory;
 import kr.it.pullit.modules.questionset.web.dto.request.QuestionSetUpdateRequestDto;
@@ -21,8 +20,6 @@ import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
-
-import java.util.Optional;
 
 @Slf4j
 @Component

--- a/src/main/java/kr/it/pullit/modules/questionset/event/QuestionGenerationWorker.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/event/QuestionGenerationWorker.java
@@ -27,8 +27,6 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class QuestionGenerationWorker {
 
-  private static final int MAX_RETRY_COUNT = 3;
-
   private final RabbitTemplate rabbitTemplate;
   private final QuestionPublicApi questionPublicApi;
   private final QuestionSetPublicApi questionSetPublicApi;

--- a/src/main/java/kr/it/pullit/modules/questionset/event/QuestionGenerationWorker.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/event/QuestionGenerationWorker.java
@@ -9,6 +9,7 @@ import kr.it.pullit.modules.questionset.domain.entity.Question;
 import kr.it.pullit.modules.questionset.domain.entity.QuestionGenerationRequest;
 import kr.it.pullit.modules.questionset.domain.entity.QuestionGenerationSpecification;
 import kr.it.pullit.modules.questionset.domain.entity.QuestionSet;
+import kr.it.pullit.modules.questionset.client.exception.LlmException;
 import kr.it.pullit.modules.questionset.service.SourceValidator;
 import kr.it.pullit.modules.questionset.service.creationstrategy.QuestionCreationStrategyFactory;
 import kr.it.pullit.modules.questionset.web.dto.request.QuestionSetUpdateRequestDto;
@@ -21,17 +22,22 @@ import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
+import java.util.Optional;
+
 @Slf4j
 @Component
 @Profile("worker")
 @RequiredArgsConstructor
 public class QuestionGenerationWorker {
 
+  private static final int MAX_RETRY_COUNT = 3;
+
   private final RabbitTemplate rabbitTemplate;
   private final QuestionPublicApi questionPublicApi;
   private final QuestionSetPublicApi questionSetPublicApi;
   private final SourceValidator sourceValidator;
   private final QuestionCreationStrategyFactory questionCreationStrategyFactory;
+  private final QuestionGenerationFailureHandler failureHandler;
 
   @RabbitListener(queues = RabbitMqConfig.QUEUE_NAME)
   public void handleQuestionGenerationRequest(QuestionSetCreatedEvent event) {
@@ -41,7 +47,7 @@ public class QuestionGenerationWorker {
       processQuestionGeneration(event);
       handleSuccess(event);
     } catch (Exception e) {
-      handleFailure(event, e);
+      failureHandler.handle(event, e);
     }
   }
 
@@ -121,10 +127,5 @@ public class QuestionGenerationWorker {
         RabbitMqConfig.COMPLETION_EXCHANGE_NAME,
         RabbitMqConfig.COMPLETION_ROUTING_KEY,
         completionEvent);
-  }
-
-  private void handleFailure(QuestionSetCreatedEvent event, Exception e) {
-    log.error("문제 생성 중 오류 발생. QuestionSet ID: {}", event.questionSetId(), e);
-    questionSetPublicApi.markAsFailed(event.questionSetId());
   }
 }

--- a/src/main/java/kr/it/pullit/modules/questionset/exception/QuestionSetErrorCode.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/exception/QuestionSetErrorCode.java
@@ -17,7 +17,9 @@ public enum QuestionSetErrorCode implements ErrorCode {
   SOURCE_NOT_READY(
       HttpStatus.BAD_REQUEST, "QSE_007", "아직 처리 중인 소스 파일이 있어 문제집을 생성할 수 없습니다. (Source IDs: %s)"),
   UNSUPPORTED_QUESTION_TYPE(
-      HttpStatus.INTERNAL_SERVER_ERROR, "QSE_008", "지원하지 않는 문제 유형입니다. (Type: %s)");
+      HttpStatus.INTERNAL_SERVER_ERROR, "QSE_008", "지원하지 않는 문제 유형입니다. (Type: %s)"),
+  QUESTION_SET_UNPROCESSABLE(
+      HttpStatus.UNPROCESSABLE_ENTITY, "QSE_009", "영구적인 오류로 인해 문제집을 처리할 수 없습니다.");
 
   private final HttpStatus status;
   private final String code;

--- a/src/main/java/kr/it/pullit/modules/questionset/exception/QuestionSetUnprocessableException.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/exception/QuestionSetUnprocessableException.java
@@ -1,0 +1,14 @@
+package kr.it.pullit.modules.questionset.exception;
+
+import kr.it.pullit.shared.error.BusinessException;
+
+public class QuestionSetUnprocessableException extends BusinessException {
+
+  private QuestionSetUnprocessableException(Object... args) {
+    super(QuestionSetErrorCode.QUESTION_SET_UNPROCESSABLE, args);
+  }
+
+  public static QuestionSetUnprocessableException byId(long id) {
+    return new QuestionSetUnprocessableException("ID", id);
+  }
+}

--- a/src/main/java/kr/it/pullit/modules/questionset/repository/adapter/jpa/QuestionSetJpaRepository.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/repository/adapter/jpa/QuestionSetJpaRepository.java
@@ -55,7 +55,6 @@ public interface QuestionSetJpaRepository extends JpaRepository<QuestionSet, Lon
        SELECT qs
        FROM QuestionSet qs
        LEFT JOIN FETCH qs.questions
-       LEFT JOIN FETCH qs.sources
        WHERE qs.id = :id
        AND qs.ownerId = :memberId
        AND qs.status = 'COMPLETE'

--- a/src/main/java/kr/it/pullit/modules/questionset/scheduler/QuestionSetCleanupScheduler.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/scheduler/QuestionSetCleanupScheduler.java
@@ -5,12 +5,11 @@ import java.time.LocalDateTime;
 import java.util.List;
 import kr.it.pullit.modules.questionset.api.QuestionSetPublicApi;
 import kr.it.pullit.modules.questionset.domain.entity.QuestionSet;
+import kr.it.pullit.shared.retry.RetryOnOptimisticLock;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
-import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,11 +30,7 @@ public class QuestionSetCleanupScheduler {
       lockAtMostFor = "9m",
       lockAtLeastFor = "1m")
   @Transactional
-  @Retryable(
-      value = {ObjectOptimisticLockingFailureException.class},
-      maxAttempts = 3,
-      backoff = @Backoff(delay = 1000),
-      listeners = "optimisticLockingRetryListener")
+  @RetryOnOptimisticLock(backoff = @Backoff(delay = 1000))
   public void cleanupStalePendingQuestionSets() {
     log.info("오래된 '생성중' 상태의 문제집 정리 작업을 시작합니다.");
     LocalDateTime threshold = LocalDateTime.now(clock).minusMinutes(STALE_THRESHOLD_MINUTES);

--- a/src/main/java/kr/it/pullit/modules/questionset/scheduler/QuestionSetCleanupScheduler.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/scheduler/QuestionSetCleanupScheduler.java
@@ -8,6 +8,9 @@ import kr.it.pullit.modules.questionset.domain.entity.QuestionSet;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,6 +31,11 @@ public class QuestionSetCleanupScheduler {
       lockAtMostFor = "9m",
       lockAtLeastFor = "1m")
   @Transactional
+  @Retryable(
+      value = {ObjectOptimisticLockingFailureException.class},
+      maxAttempts = 3,
+      backoff = @Backoff(delay = 1000),
+      listeners = "optimisticLockingRetryListener")
   public void cleanupStalePendingQuestionSets() {
     log.info("오래된 '생성중' 상태의 문제집 정리 작업을 시작합니다.");
     LocalDateTime threshold = LocalDateTime.now(clock).minusMinutes(STALE_THRESHOLD_MINUTES);

--- a/src/main/java/kr/it/pullit/modules/questionset/scheduler/QuestionSetRetryScheduler.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/scheduler/QuestionSetRetryScheduler.java
@@ -1,6 +1,7 @@
 package kr.it.pullit.modules.questionset.scheduler;
 
 import kr.it.pullit.modules.questionset.api.QuestionSetPublicApi;
+import kr.it.pullit.modules.questionset.domain.entity.QuestionSet;
 import kr.it.pullit.modules.questionset.event.QuestionSetCreatedEvent;
 import kr.it.pullit.shared.event.EventPublisher;
 import lombok.RequiredArgsConstructor;
@@ -16,8 +17,6 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class QuestionSetRetryScheduler {
-
-  private static final int MAX_RETRY_COUNT = 3;
 
   private final QuestionSetPublicApi questionSetPublicApi;
   private final EventPublisher eventPublisher;
@@ -36,7 +35,7 @@ public class QuestionSetRetryScheduler {
     log.info("'생성실패' 상태의 문제집 재시도 작업을 시작합니다.");
 
     questionSetPublicApi
-        .claimOneForRetry(MAX_RETRY_COUNT)
+        .claimOneForRetry(QuestionSet.MAX_RETRY_COUNT)
         .ifPresent(
             questionSet -> {
               log.info(

--- a/src/main/java/kr/it/pullit/modules/questionset/scheduler/QuestionSetRetryScheduler.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/scheduler/QuestionSetRetryScheduler.java
@@ -6,6 +6,9 @@ import kr.it.pullit.shared.event.EventPublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -24,6 +27,11 @@ public class QuestionSetRetryScheduler {
       name = "retryFailedQuestionSetGeneration",
       lockAtMostFor = "4m",
       lockAtLeastFor = "1m")
+  @Retryable(
+      value = {ObjectOptimisticLockingFailureException.class},
+      maxAttempts = 3,
+      backoff = @Backoff(delay = 1000),
+      listeners = "optimisticLockingRetryListener")
   public void retryFailedQuestionSetGeneration() {
     log.info("'생성실패' 상태의 문제집 재시도 작업을 시작합니다.");
 

--- a/src/main/java/kr/it/pullit/modules/questionset/scheduler/QuestionSetRetryScheduler.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/scheduler/QuestionSetRetryScheduler.java
@@ -4,12 +4,11 @@ import kr.it.pullit.modules.questionset.api.QuestionSetPublicApi;
 import kr.it.pullit.modules.questionset.domain.entity.QuestionSet;
 import kr.it.pullit.modules.questionset.event.QuestionSetCreatedEvent;
 import kr.it.pullit.shared.event.EventPublisher;
+import kr.it.pullit.shared.retry.RetryOnOptimisticLock;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
-import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -26,11 +25,7 @@ public class QuestionSetRetryScheduler {
       name = "retryFailedQuestionSetGeneration",
       lockAtMostFor = "4m",
       lockAtLeastFor = "1m")
-  @Retryable(
-      value = {ObjectOptimisticLockingFailureException.class},
-      maxAttempts = 3,
-      backoff = @Backoff(delay = 1000),
-      listeners = "optimisticLockingRetryListener")
+  @RetryOnOptimisticLock(backoff = @Backoff(delay = 1000))
   public void retryFailedQuestionSetGeneration() {
     log.info("'생성실패' 상태의 문제집 재시도 작업을 시작합니다.");
 

--- a/src/main/java/kr/it/pullit/modules/questionset/service/QuestionSetExceptionHandler.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/service/QuestionSetExceptionHandler.java
@@ -1,0 +1,49 @@
+package kr.it.pullit.modules.questionset.service;
+
+import kr.it.pullit.modules.questionset.domain.entity.QuestionSet;
+import kr.it.pullit.modules.questionset.enums.QuestionSetStatus;
+import kr.it.pullit.modules.questionset.exception.QuestionSetFailedException;
+import kr.it.pullit.modules.questionset.exception.QuestionSetNotFoundException;
+import kr.it.pullit.modules.questionset.exception.QuestionSetNotReadyException;
+import kr.it.pullit.modules.questionset.exception.QuestionSetUnprocessableException;
+import kr.it.pullit.modules.questionset.repository.QuestionSetRepository;
+import kr.it.pullit.modules.wronganswer.exception.WrongAnswerNotFoundException;
+import kr.it.pullit.shared.error.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class QuestionSetExceptionHandler {
+
+  private final QuestionSetRepository questionSetRepository;
+
+  public RuntimeException handleReviewSetNotFound(Long id, Long memberId) {
+    QuestionSet qs =
+        questionSetRepository
+            .findByIdAndMemberId(id, memberId)
+            .orElseThrow(() -> QuestionSetNotFoundException.byId(id));
+
+    if (qs.getStatus() != QuestionSetStatus.COMPLETE) {
+      return handleQuestionSetStatusException(qs);
+    }
+
+    return WrongAnswerNotFoundException.noWrongAnswersToReview();
+  }
+
+  public RuntimeException handleQuestionSetNotFound(Long id, Long memberId) {
+    return questionSetRepository
+        .findByIdAndMemberId(id, memberId)
+        .map(this::handleQuestionSetStatusException)
+        .orElse(QuestionSetNotFoundException.byId(id));
+  }
+
+  private BusinessException handleQuestionSetStatusException(QuestionSet qs) {
+    return switch (qs.getStatus()) {
+      case PENDING -> QuestionSetNotReadyException.byId(qs.getId());
+      case FAILED -> QuestionSetFailedException.byId(qs.getId());
+      case UNPROCESSABLE -> QuestionSetUnprocessableException.byId(qs.getId());
+      default -> QuestionSetNotFoundException.byId(qs.getId());
+    };
+  }
+}

--- a/src/main/java/kr/it/pullit/modules/questionset/service/QuestionSetService.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/service/QuestionSetService.java
@@ -224,6 +224,13 @@ public class QuestionSetService implements QuestionSetPublicApi {
 
   @Override
   @Transactional
+  public void markAsUnprocessable(Long questionSetId) {
+    QuestionSet questionSet = findQuestionSetOrThrow(questionSetId);
+    questionSet.markAsUnprocessable();
+  }
+
+  @Override
+  @Transactional
   @Retryable(
       value = {ObjectOptimisticLockingFailureException.class},
       maxAttempts = 3,
@@ -276,11 +283,6 @@ public class QuestionSetService implements QuestionSetPublicApi {
     CommonFolder defaultFolder =
         commonFolderPublicApi.getOrCreateDefaultQuestionSetFolder(memberId);
     questionSetRepository.relocateAllByFolderIdToDefaultFolder(folderId, defaultFolder.getId());
-  }
-
-  @Override
-  public List<QuestionSet> findAllByFolderId(Long folderId) {
-    return questionSetRepository.findAllByCommonFolderId(folderId);
   }
 
   @Override

--- a/src/main/java/kr/it/pullit/modules/questionset/service/QuestionSetService.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/service/QuestionSetService.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Optional;
 import kr.it.pullit.modules.commonfolder.api.CommonFolderPublicApi;
 import kr.it.pullit.modules.commonfolder.domain.entity.CommonFolder;
+import kr.it.pullit.modules.commonfolder.exception.FolderNotFoundException;
 import kr.it.pullit.modules.learningsource.source.api.SourcePublicApi;
 import kr.it.pullit.modules.learningsource.source.constant.SourceStatus;
 import kr.it.pullit.modules.learningsource.source.domain.entity.Source;
@@ -18,9 +19,7 @@ import kr.it.pullit.modules.questionset.domain.entity.Question;
 import kr.it.pullit.modules.questionset.domain.entity.QuestionSet;
 import kr.it.pullit.modules.questionset.enums.QuestionSetStatus;
 import kr.it.pullit.modules.questionset.event.QuestionSetCreatedEvent;
-import kr.it.pullit.modules.questionset.exception.QuestionSetFailedException;
 import kr.it.pullit.modules.questionset.exception.QuestionSetNotFoundException;
-import kr.it.pullit.modules.questionset.exception.QuestionSetNotReadyException;
 import kr.it.pullit.modules.questionset.exception.QuestionSetUnauthorizedException;
 import kr.it.pullit.modules.questionset.exception.SourceNotReadyException;
 import kr.it.pullit.modules.questionset.repository.MarkingResultRepository;
@@ -30,8 +29,6 @@ import kr.it.pullit.modules.questionset.web.dto.request.QuestionSetCreateRequest
 import kr.it.pullit.modules.questionset.web.dto.request.QuestionSetUpdateRequestDto;
 import kr.it.pullit.modules.questionset.web.dto.response.MyQuestionSetsResponse;
 import kr.it.pullit.modules.questionset.web.dto.response.QuestionSetResponse;
-import kr.it.pullit.modules.wronganswer.exception.WrongAnswerNotFoundException;
-import kr.it.pullit.shared.error.BusinessException;
 import kr.it.pullit.shared.event.EventPublisher;
 import kr.it.pullit.shared.paging.dto.CursorPageResponse;
 import lombok.RequiredArgsConstructor;
@@ -53,6 +50,7 @@ public class QuestionSetService implements QuestionSetPublicApi {
   private final SourcePublicApi sourcePublicApi;
   private final MemberPublicApi memberPublicApi;
   private final EventPublisher eventPublisher;
+  private final QuestionSetExceptionHandler exceptionHandler;
 
   @Override
   @Transactional(readOnly = true)
@@ -75,7 +73,7 @@ public class QuestionSetService implements QuestionSetPublicApi {
     QuestionSet questionSet =
         questionSetRepository
             .findWithQuestionsForFirstSolving(id, memberId)
-            .orElseThrow(() -> handleQuestionSetNotFound(id, memberId));
+            .orElseThrow(() -> exceptionHandler.handleQuestionSetNotFound(id, memberId));
 
     return QuestionSetResponse.from(questionSet);
   }
@@ -84,35 +82,7 @@ public class QuestionSetService implements QuestionSetPublicApi {
     return questionSetRepository
         .findQuestionSetForReviewing(id, memberId)
         .map(QuestionSetResponse::from)
-        .orElseThrow(() -> handleReviewSetNotFound(id, memberId));
-  }
-
-  private RuntimeException handleReviewSetNotFound(Long id, Long memberId) {
-    QuestionSet qs =
-        questionSetRepository
-            .findByIdAndMemberId(id, memberId)
-            .orElseThrow(() -> QuestionSetNotFoundException.byId(id));
-
-    if (qs.getStatus() != QuestionSetStatus.COMPLETE) {
-      return handleQuestionSetStatusException(qs);
-    }
-
-    return WrongAnswerNotFoundException.noWrongAnswersToReview();
-  }
-
-  private RuntimeException handleQuestionSetNotFound(Long id, Long memberId) {
-    return questionSetRepository
-        .findByIdAndMemberId(id, memberId)
-        .map(this::handleQuestionSetStatusException)
-        .orElse(QuestionSetNotFoundException.byId(id));
-  }
-
-  private BusinessException handleQuestionSetStatusException(QuestionSet qs) {
-    return switch (qs.getStatus()) {
-      case PENDING -> QuestionSetNotReadyException.byId(qs.getId());
-      case FAILED -> QuestionSetFailedException.byId(qs.getId());
-      default -> QuestionSetNotFoundException.byId(qs.getId());
-    };
+        .orElseThrow(() -> exceptionHandler.handleReviewSetNotFound(id, memberId));
   }
 
   @Transactional
@@ -278,7 +248,7 @@ public class QuestionSetService implements QuestionSetPublicApi {
   public void relocateQuestionSetsToDefaultFolder(Long memberId, Long folderId) {
     commonFolderPublicApi
         .findFolderEntityById(memberId, folderId)
-        .orElseThrow(() -> new IllegalArgumentException("해당 ID의 폴더를 찾을 수 없거나 권한이 없습니다."));
+        .orElseThrow(() -> FolderNotFoundException.byId(folderId));
 
     CommonFolder defaultFolder =
         commonFolderPublicApi.getOrCreateDefaultQuestionSetFolder(memberId);

--- a/src/main/java/kr/it/pullit/shared/retry/OptimisticLockingRetryListener.java
+++ b/src/main/java/kr/it/pullit/shared/retry/OptimisticLockingRetryListener.java
@@ -1,4 +1,4 @@
-package kr.it.pullit.shared.support.retry;
+package kr.it.pullit.shared.retry;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;

--- a/src/main/java/kr/it/pullit/shared/retry/RetryOnOptimisticLock.java
+++ b/src/main/java/kr/it/pullit/shared/retry/RetryOnOptimisticLock.java
@@ -16,15 +16,11 @@ import org.springframework.retry.annotation.Retryable;
     listeners = "optimisticLockingRetryListener")
 public @interface RetryOnOptimisticLock {
 
-  /**
-   * 호출 지점에서 backoff 전략을 바꿔 쓸 수 있도록 노출합니다. 기본은 1초 지연.
-   */
+  /** 호출 지점에서 backoff 전략을 바꿔 쓸 수 있도록 노출합니다. 기본은 1초 지연. */
   @AliasFor(annotation = Retryable.class, attribute = "backoff")
   Backoff backoff() default @Backoff(delay = 1000);
 
-  /**
-   * 최대 시도 횟수를 노출합니다. (기본값 3 — Retryable 기본과 동일)
-   */
+  /** 최대 시도 횟수를 노출합니다. (기본값 3 — Retryable 기본과 동일) */
   @AliasFor(annotation = Retryable.class, attribute = "maxAttempts")
   int maxAttempts() default 3;
 }

--- a/src/main/java/kr/it/pullit/shared/retry/RetryOnOptimisticLock.java
+++ b/src/main/java/kr/it/pullit/shared/retry/RetryOnOptimisticLock.java
@@ -1,0 +1,30 @@
+package kr.it.pullit.shared.retry;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Retryable(
+    retryFor = ObjectOptimisticLockingFailureException.class,
+    listeners = "optimisticLockingRetryListener")
+public @interface RetryOnOptimisticLock {
+
+  /**
+   * 호출 지점에서 backoff 전략을 바꿔 쓸 수 있도록 노출합니다. 기본은 1초 지연.
+   */
+  @AliasFor(annotation = Retryable.class, attribute = "backoff")
+  Backoff backoff() default @Backoff(delay = 1000);
+
+  /**
+   * 최대 시도 횟수를 노출합니다. (기본값 3 — Retryable 기본과 동일)
+   */
+  @AliasFor(annotation = Retryable.class, attribute = "maxAttempts")
+  int maxAttempts() default 3;
+}

--- a/src/main/java/kr/it/pullit/shared/support/retry/OptimisticLockingRetryListener.java
+++ b/src/main/java/kr/it/pullit/shared/support/retry/OptimisticLockingRetryListener.java
@@ -1,0 +1,21 @@
+package kr.it.pullit.shared.support.retry;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.RetryListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component("optimisticLockingRetryListener")
+public class OptimisticLockingRetryListener implements RetryListener {
+
+  @Override
+  public <T, E extends Throwable> void onError(
+      RetryContext context, RetryCallback<T, E> callback, Throwable throwable) {
+    if (throwable instanceof ObjectOptimisticLockingFailureException) {
+      log.warn("[재시도 경고] 낙관적 락 충돌이 감지되어 재시도합니다. (시도 횟수: {})", context.getRetryCount(), throwable);
+    }
+  }
+}

--- a/src/test/java/kr/it/pullit/modules/questionset/client/exception/LlmExceptionTest.java
+++ b/src/test/java/kr/it/pullit/modules/questionset/client/exception/LlmExceptionTest.java
@@ -10,7 +10,7 @@ class LlmExceptionTest {
   @Test
   @DisplayName("생성 실패 사유를 포함한 예외를 생성한다")
   void generationFailedIncludesReason() {
-    LlmException exception = LlmException.generationFailed("네트워크 오류");
+    LlmException exception = LlmException.ofTemporary("네트워크 오류");
 
     assertThat(exception.getErrorCode()).isEqualTo(LlmErrorCode.LLM_GENERATION_FAILED);
     assertThat(exception).hasMessageContaining("네트워크 오류");
@@ -21,7 +21,7 @@ class LlmExceptionTest {
   void withCauseWrapsOriginalMessage() {
     IllegalStateException cause = new IllegalStateException("API unavailable");
 
-    LlmException exception = LlmException.withCause(cause);
+    LlmException exception = LlmException.from(cause);
 
     assertThat(exception.getErrorCode()).isEqualTo(LlmErrorCode.LLM_GENERATION_FAILED);
     assertThat(exception).hasMessageContaining("API unavailable");

--- a/src/test/java/kr/it/pullit/modules/questionset/service/QuestionSetServiceTest.java
+++ b/src/test/java/kr/it/pullit/modules/questionset/service/QuestionSetServiceTest.java
@@ -53,13 +53,14 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @MockitoUnitTest
 @DisplayName("QuestionSetService 단위 테스트")
 class QuestionSetServiceTest {
 
-  @InjectMocks private QuestionSetService questionSetService;
+  private QuestionSetService questionSetService;
 
   @Mock private QuestionSetRepository questionSetRepository;
   @Mock private CommonFolderPublicApi commonFolderPublicApi;
@@ -72,6 +73,8 @@ class QuestionSetServiceTest {
 
   @BeforeEach
   void setUp() {
+    QuestionSetExceptionHandler questionSetExceptionHandler = new QuestionSetExceptionHandler(
+        questionSetRepository);
     questionSetService =
         new QuestionSetService(
             questionSetRepository,
@@ -81,7 +84,8 @@ class QuestionSetServiceTest {
             commonFolderPublicApi,
             sourcePublicApi,
             memberPublicApi,
-            eventPublisher);
+            eventPublisher,
+            questionSetExceptionHandler);
   }
 
   @Nested

--- a/src/test/java/kr/it/pullit/modules/questionset/service/QuestionSetServiceTest.java
+++ b/src/test/java/kr/it/pullit/modules/questionset/service/QuestionSetServiceTest.java
@@ -51,9 +51,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Spy;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @MockitoUnitTest
@@ -73,8 +71,8 @@ class QuestionSetServiceTest {
 
   @BeforeEach
   void setUp() {
-    QuestionSetExceptionHandler questionSetExceptionHandler = new QuestionSetExceptionHandler(
-        questionSetRepository);
+    QuestionSetExceptionHandler questionSetExceptionHandler =
+        new QuestionSetExceptionHandler(questionSetRepository);
     questionSetService =
         new QuestionSetService(
             questionSetRepository,


### PR DESCRIPTION
<!-- PR 제목을 `이슈번호: 작업내용(명확히)`로 작성해주세요. -->

## PR 설명

스케줄링 재시도 로직 및 로그 및 낙관적 락 에러 로그 경고로 변경

<!--Release Notes:

- N/A _or_ Added/Fixed/Improved ...-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Better handling for question-generation failures: distinguishes permanent vs temporary errors; new UNPROCESSABLE state and ability to mark question sets unprocessable.

* **Bug Fixes / Reliability**
  * Added optimistic-lock retry and extended locking for multiple scheduled jobs and outbox relay to improve background job reliability.
  * Added batch processing dependency support.

* **Documentation**
  * Clarified source deletion behavior in code comments.

* **Chores**
  * Ignore local PEM SSL certs in repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->