### PR TITLE
btsk-122: learn-stat-계산방식 변경 및 마이그레이션 api에도 잔디 값 바꾸도록 변경

### DIFF
--- a/docker-compose.qa.yml
+++ b/docker-compose.qa.yml
@@ -86,6 +86,8 @@ services:
     environment:
       <<: *pullit-common-env
       SPRING_PROFILES_ACTIVE: qa,worker
+      SPRING_MAIN_WEB_APPLICATION_TYPE: NONE
+      MANAGEMENT_SERVER_PORT: 8080
 
   pullit-qa-worker-green:
     restart: unless-stopped
@@ -109,6 +111,8 @@ services:
     environment:
       <<: *pullit-common-env
       SPRING_PROFILES_ACTIVE: qa,worker
+      SPRING_MAIN_WEB_APPLICATION_TYPE: NONE
+      MANAGEMENT_SERVER_PORT: 8080
 
   pullit-qa-db:
     image: mariadb:10.11

--- a/src/main/java/kr/it/pullit/modules/projection/learnstats/api/LearnStatsEventPublicApi.java
+++ b/src/main/java/kr/it/pullit/modules/projection/learnstats/api/LearnStatsEventPublicApi.java
@@ -6,5 +6,5 @@ public interface LearnStatsEventPublicApi {
 
   void publishQuestionSetSolved(Long memberId, int solvedQuestionCount);
 
-  void publishCorrectAnswerCount(Long memberId, long correctCount);
+  void publishRecalculateCorrectAnswerCount(Long memberId);
 }

--- a/src/main/java/kr/it/pullit/modules/projection/learnstats/domain/LearnStats.java
+++ b/src/main/java/kr/it/pullit/modules/projection/learnstats/domain/LearnStats.java
@@ -8,7 +8,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
+import java.util.Comparator;
 import java.util.List;
 import kr.it.pullit.modules.projection.learnstats.exception.InvalidSolvedQuestionCountException;
 import kr.it.pullit.shared.jpa.BaseEntity;
@@ -78,7 +78,6 @@ public class LearnStats extends BaseEntity {
     this.totalSolvedQuestionSetCount++;
     this.totalSolvedQuestionCount += solvedQuestionCount;
     this.weeklySolvedQuestionCount += solvedQuestionCount;
-    updateConsecutiveStreak(today);
   }
 
   public void onQuestionSetDeleted(long correctQuestionsInSet) {
@@ -94,57 +93,54 @@ public class LearnStats extends BaseEntity {
     this.totalSolvedQuestionCount = realCount;
   }
 
-  public void increaseCorrectQuestionCount(long correctCount) {
-    if (correctCount > 0) {
-      this.totalCorrectQuestionCount += correctCount;
-    }
+  public void updateTotalCorrectQuestionCount(long totalCorrectQuestionCount) {
+    this.totalCorrectQuestionCount = totalCorrectQuestionCount;
   }
 
   public void recalibrate(
       long totalAttemptedQuestionCount,
       long totalCorrectQuestionCount,
       int weeklySolvedQuestionCount,
-      List<LocalDateTime> completedDates) {
+      List<LocalDateTime> completedDates,
+      LocalDate today) {
     this.totalSolvedQuestionCount = totalAttemptedQuestionCount;
     this.totalCorrectQuestionCount = totalCorrectQuestionCount;
     this.weeklySolvedQuestionCount = weeklySolvedQuestionCount;
-    this.consecutiveLearningDays = calculateConsecutiveDaysFrom(completedDates);
+    this.consecutiveLearningDays = calculateCurrentStreakFrom(completedDates, today);
     this.lastLearningDate = findLastLearningDateFrom(completedDates);
   }
 
-  private int calculateConsecutiveDaysFrom(List<LocalDateTime> completedDates) {
+  private int calculateCurrentStreakFrom(List<LocalDateTime> completedDates, LocalDate today) {
     if (completedDates == null || completedDates.isEmpty()) {
       return 0;
     }
 
-    List<LocalDateTime> sortedCompletedDates = completedDates.stream().sorted().toList();
+    List<LocalDate> distinctSortedDates =
+        completedDates.stream()
+            .map(LocalDateTime::toLocalDate)
+            .distinct()
+            .sorted(Comparator.reverseOrder())
+            .toList();
 
-    int consecutiveDays = 0;
-    LocalDate previousDate = null;
+    LocalDate lastDate = distinctSortedDates.get(0);
 
-    for (LocalDateTime completedDateTime : sortedCompletedDates) {
-      LocalDate currentDate = completedDateTime.toLocalDate();
-      consecutiveDays = updateConsecutiveCount(consecutiveDays, previousDate, currentDate);
-      previousDate = currentDate;
+    if (DAYS.between(lastDate, today) > 1) {
+      return 0;
+    }
+
+    int consecutiveDays = 1;
+    LocalDate previousDate = lastDate;
+
+    for (int i = 1; i < distinctSortedDates.size(); i++) {
+      LocalDate currentDate = distinctSortedDates.get(i);
+      if (DAYS.between(currentDate, previousDate) == 1) {
+        consecutiveDays++;
+        previousDate = currentDate;
+      } else {
+        break;
+      }
     }
     return consecutiveDays;
-  }
-
-  private int updateConsecutiveCount(
-      int currentConsecutiveDays, LocalDate previousDate, LocalDate currentDate) {
-    if (previousDate == null) {
-      return 1;
-    }
-
-    long daysBetween = ChronoUnit.DAYS.between(previousDate, currentDate);
-
-    if (daysBetween == 1) {
-      return currentConsecutiveDays + 1;
-    }
-    if (daysBetween > 1) {
-      return 1;
-    }
-    return currentConsecutiveDays;
   }
 
   private LocalDate findLastLearningDateFrom(List<LocalDateTime> completedDates) {
@@ -155,38 +151,6 @@ public class LearnStats extends BaseEntity {
         .map(LocalDateTime::toLocalDate)
         .max(LocalDate::compareTo)
         .orElse(null);
-  }
-
-  private void updateConsecutiveStreak(LocalDate today) {
-    if (lastLearningDate == null) {
-      consecutiveLearningDays = 1;
-      lastLearningDate = today;
-      return;
-    }
-
-    int delta = (int) DAYS.between(lastLearningDate, today);
-
-    if (isSameOrPastDay(delta)) {
-      updateLastLearningDateIfNeeded(today);
-      return;
-    }
-
-    updateConsecutiveDays(delta);
-    lastLearningDate = today;
-  }
-
-  private void updateConsecutiveDays(int delta) {
-    consecutiveLearningDays = (delta == 1) ? consecutiveLearningDays + 1 : 1;
-  }
-
-  private void updateLastLearningDateIfNeeded(LocalDate today) {
-    if (today.isAfter(lastLearningDate)) {
-      lastLearningDate = today;
-    }
-  }
-
-  private boolean isSameOrPastDay(int delta) {
-    return delta <= 0;
   }
 
   public void resetConsecutiveDaysIfMissed(LocalDate today) {

--- a/src/main/java/kr/it/pullit/modules/projection/learnstats/event/handler/LearnStatsEventDispatcher.java
+++ b/src/main/java/kr/it/pullit/modules/projection/learnstats/event/handler/LearnStatsEventDispatcher.java
@@ -41,7 +41,7 @@ public class LearnStatsEventDispatcher {
       case CORRECT_ANSWER_COUNT_INCREASED -> {
         CorrectAnswerPayload payload =
             objectMapper.readValue(e.getPayload(), CorrectAnswerPayload.class);
-        projectionService.increaseCorrectQuestionCount(payload.memberId(), payload.correctCount());
+        projectionService.recalculateCorrectQuestionCount(payload.memberId());
       }
       default -> {
         return false;

--- a/src/main/java/kr/it/pullit/modules/projection/learnstats/event/publisher/LearnStatsEventPublisher.java
+++ b/src/main/java/kr/it/pullit/modules/projection/learnstats/event/publisher/LearnStatsEventPublisher.java
@@ -41,8 +41,8 @@ public class LearnStatsEventPublisher implements LearnStatsEventPublicApi {
 
   @Override
   @SneakyThrows
-  public void publishCorrectAnswerCount(Long memberId, long correctCount) {
-    CorrectAnswerPayload payload = new CorrectAnswerPayload(memberId, correctCount);
+  public void publishRecalculateCorrectAnswerCount(Long memberId) {
+    CorrectAnswerPayload payload = new CorrectAnswerPayload(memberId, 0);
     String jsonPayload = objectMapper.writeValueAsString(payload);
     OutboxEvent event =
         OutboxEvent.of(

--- a/src/main/java/kr/it/pullit/modules/projection/learnstats/service/LearnStatsRecalibrationService.java
+++ b/src/main/java/kr/it/pullit/modules/projection/learnstats/service/LearnStatsRecalibrationService.java
@@ -2,6 +2,7 @@ package kr.it.pullit.modules.projection.learnstats.service;
 
 import java.time.Clock;
 import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.TemporalAdjusters;
 import java.util.List;
@@ -70,7 +71,12 @@ public class LearnStatsRecalibrationService implements LearnStatsRecalibrationPu
     LearnStats stats =
         learnStatsRepository.findById(memberId).orElseGet(() -> LearnStats.newOf(memberId));
 
-    stats.recalibrate(totalAttemptedCount, totalCorrectCount, weeklySolvedCount, completedDates);
+    stats.recalibrate(
+        totalAttemptedCount,
+        totalCorrectCount,
+        weeklySolvedCount,
+        completedDates,
+        LocalDate.now(clock));
     stats.updateTotalQuestionCount(totalQuestionCount);
 
     learnStatsRepository.save(stats);

--- a/src/main/java/kr/it/pullit/modules/projection/learnstats/service/LearnStatsService.java
+++ b/src/main/java/kr/it/pullit/modules/projection/learnstats/service/LearnStatsService.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import kr.it.pullit.modules.projection.learnstats.api.LearnStatsPublicApi;
 import kr.it.pullit.modules.projection.learnstats.domain.LearnStats;
 import kr.it.pullit.modules.projection.learnstats.repository.LearnStatsRepository;
+import kr.it.pullit.modules.questionset.api.MarkingResultPublicApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class LearnStatsService implements LearnStatsPublicApi {
 
   private final LearnStatsRepository repo;
+  private final MarkingResultPublicApi markingResultPublicApi;
   private final Clock clock;
 
   @Override
@@ -32,6 +34,14 @@ public class LearnStatsService implements LearnStatsPublicApi {
     repo.save(p);
   }
 
+  public void recalculateCorrectQuestionCount(Long memberId) {
+    long totalCorrectQuestionCount = markingResultPublicApi.countCorrectAnswersByMemberId(memberId);
+
+    LearnStats p = repo.findById(memberId).orElseGet(() -> LearnStats.newOf(memberId));
+    p.updateTotalCorrectQuestionCount(totalCorrectQuestionCount);
+    repo.save(p);
+  }
+
   @Override
   public void applyQuestionSetDeleted(Long memberId, long correctQuestionCount) {
     repo.findById(memberId)
@@ -40,12 +50,6 @@ public class LearnStatsService implements LearnStatsPublicApi {
               learnStats.onQuestionSetDeleted(correctQuestionCount);
               repo.save(learnStats);
             });
-  }
-
-  public void increaseCorrectQuestionCount(Long memberId, long correctCount) {
-    LearnStats p = repo.findById(memberId).orElseGet(() -> LearnStats.newOf(memberId));
-    p.increaseCorrectQuestionCount(correctCount);
-    repo.save(p);
   }
 
   @Override

--- a/src/main/java/kr/it/pullit/modules/questionset/api/MarkingResultPublicApi.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/api/MarkingResultPublicApi.java
@@ -16,4 +16,6 @@ public interface MarkingResultPublicApi {
    * @return 총 맞힌 문제 수
    */
   long countTotalCorrectQuestionsByMemberId(Long memberId);
+
+  long countCorrectAnswersByMemberId(Long memberId);
 }

--- a/src/main/java/kr/it/pullit/modules/questionset/event/MarkingCompletedEventHandler.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/event/MarkingCompletedEventHandler.java
@@ -25,9 +25,9 @@ public class MarkingCompletedEventHandler {
       return;
     }
 
-    long correctCount = event.results().stream().filter(MarkingResultDto::isCorrect).count();
-    if (correctCount > 0) {
-      learnStatsEventPublicApi.publishCorrectAnswerCount(event.memberId(), correctCount);
+    boolean hasCorrectAnswer = event.results().stream().anyMatch(MarkingResultDto::isCorrect);
+    if (hasCorrectAnswer) {
+      learnStatsEventPublicApi.publishRecalculateCorrectAnswerCount(event.memberId());
     }
 
     learnStatsEventPublicApi.publishQuestionSetSolved(event.memberId(), event.results().size());

--- a/src/main/java/kr/it/pullit/modules/questionset/event/MarkingCompletedEventHandler.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/event/MarkingCompletedEventHandler.java
@@ -2,7 +2,6 @@ package kr.it.pullit.modules.questionset.event;
 
 import kr.it.pullit.modules.projection.learnstats.api.LearnStatsDailyPublicApi;
 import kr.it.pullit.modules.projection.learnstats.api.LearnStatsEventPublicApi;
-import kr.it.pullit.modules.questionset.web.dto.response.MarkingResultDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
@@ -25,10 +24,7 @@ public class MarkingCompletedEventHandler {
       return;
     }
 
-    boolean hasCorrectAnswer = event.results().stream().anyMatch(MarkingResultDto::isCorrect);
-    if (hasCorrectAnswer) {
-      learnStatsEventPublicApi.publishRecalculateCorrectAnswerCount(event.memberId());
-    }
+    learnStatsEventPublicApi.publishRecalculateCorrectAnswerCount(event.memberId());
 
     learnStatsEventPublicApi.publishQuestionSetSolved(event.memberId(), event.results().size());
     learnStatsDailyPublicApi.addDailyStats(event.memberId(), event.results().size(), 1);

--- a/src/main/java/kr/it/pullit/modules/questionset/repository/MarkingResultRepository.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/repository/MarkingResultRepository.java
@@ -12,4 +12,6 @@ public interface MarkingResultRepository {
   long countDistinctQuestionByMemberId(Long memberId);
 
   long countByMemberIdAndIsCorrectIsTrue(Long memberId);
+
+  long countCorrectAnswersByMemberId(Long memberId);
 }

--- a/src/main/java/kr/it/pullit/modules/questionset/repository/MarkingResultRepositoryImpl.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/repository/MarkingResultRepositoryImpl.java
@@ -36,4 +36,9 @@ public class MarkingResultRepositoryImpl implements MarkingResultRepository {
   public long countByMemberIdAndIsCorrectIsTrue(Long memberId) {
     return jpaRepository.countByMemberIdAndIsCorrectIsTrue(memberId);
   }
+
+  @Override
+  public long countCorrectAnswersByMemberId(Long memberId) {
+    return jpaRepository.countCorrectAnswersByMemberId(memberId);
+  }
 }

--- a/src/main/java/kr/it/pullit/modules/questionset/repository/adapter/jpa/MarkingResultJpaRepository.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/repository/adapter/jpa/MarkingResultJpaRepository.java
@@ -14,9 +14,21 @@ public interface MarkingResultJpaRepository extends JpaRepository<MarkingResult,
 
   @Query(
       """
-      SELECT COUNT(DISTINCT mr.question.id) FROM marking_result mr WHERE mr.memberId = :memberId
+      SELECT
+        COUNT(DISTINCT mr.question.id)
+        FROM marking_result mr
+        WHERE mr.memberId = :memberId
       """)
   long countDistinctQuestionByMemberId(@Param("memberId") Long memberId);
 
   long countByMemberIdAndIsCorrectIsTrue(Long memberId);
+
+  @Query(
+      """
+      SELECT count(mr)
+        FROM marking_result mr
+        WHERE mr.memberId = :memberId
+        AND mr.isCorrect = true
+      """)
+  long countCorrectAnswersByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/kr/it/pullit/modules/questionset/service/MarkingResultService.java
+++ b/src/main/java/kr/it/pullit/modules/questionset/service/MarkingResultService.java
@@ -22,4 +22,9 @@ public class MarkingResultService implements MarkingResultPublicApi {
   public long countTotalCorrectQuestionsByMemberId(Long memberId) {
     return markingResultRepository.countByMemberIdAndIsCorrectIsTrue(memberId);
   }
+
+  @Override
+  public long countCorrectAnswersByMemberId(Long memberId) {
+    return markingResultRepository.countCorrectAnswersByMemberId(memberId);
+  }
 }

--- a/src/test/java/kr/it/pullit/modules/projection/learnstats/domain/LearnStatsTest.java
+++ b/src/test/java/kr/it/pullit/modules/projection/learnstats/domain/LearnStatsTest.java
@@ -53,15 +53,13 @@ class LearnStatsTest {
   class OnQuestionSetSolved {
 
     @Test
-    @DisplayName("문제집 풀이 통계와 연속 학습일이 업데이트된다")
+    @DisplayName("문제집 풀이 관련 통계가 정상적으로 업데이트된다")
     void updatesStatsCorrectly() {
       projection.onQuestionSetSolved(15, today);
 
       assertThat(projection.getTotalSolvedQuestionSetCount()).isEqualTo(1);
       assertThat(projection.getTotalSolvedQuestionCount()).isEqualTo(15);
       assertThat(projection.getWeeklySolvedQuestionCount()).isEqualTo(15);
-      assertThat(projection.getConsecutiveLearningDays()).isEqualTo(1);
-      assertThat(projection.getLastLearningDate()).isEqualTo(today);
     }
 
     @Test
@@ -74,43 +72,26 @@ class LearnStatsTest {
     }
 
     @Test
-    @DisplayName("같은 날 여러번 풀어도 연속 학습일은 1을 유지한다")
+    @DisplayName("같은 날 여러번 풀어도 풀이 통계가 누적된다")
     void withMultipleSolvesOnSameDay_maintainsConsecutiveDays() {
       // when
       projection.onQuestionSetSolved(10, today);
       projection.onQuestionSetSolved(5, today);
 
       // then
-      assertThat(projection.getConsecutiveLearningDays()).isEqualTo(1);
       assertThat(projection.getTotalSolvedQuestionSetCount()).isEqualTo(2);
       assertThat(projection.getTotalSolvedQuestionCount()).isEqualTo(15);
     }
+  }
 
-    @Test
-    @DisplayName("다음 날 풀면 연속 학습일이 증가한다")
-    void withSolveOnNextDay_incrementsConsecutiveDays() {
-      // given
-      projection.onQuestionSetSolved(10, today);
+  @Test
+  @DisplayName("updateTotalCorrectQuestionCount: 맞은 문제 수를 업데이트한다")
+  void updateTotalCorrectQuestionCount() {
+    // when
+    projection.updateTotalCorrectQuestionCount(100L);
 
-      // when
-      projection.onQuestionSetSolved(5, today.plusDays(1));
-
-      // then
-      assertThat(projection.getConsecutiveLearningDays()).isEqualTo(2);
-    }
-
-    @Test
-    @DisplayName("이틀 이상 뒤에 풀면 연속 학습일이 1로 초기화된다")
-    void withSolveAfterGap_resetsConsecutiveDays() {
-      // given
-      projection.onQuestionSetSolved(10, today);
-
-      // when
-      projection.onQuestionSetSolved(5, today.plusDays(3));
-
-      // then
-      assertThat(projection.getConsecutiveLearningDays()).isEqualTo(1);
-    }
+    // then
+    assertThat(projection.getTotalCorrectQuestionCount()).isEqualTo(100L);
   }
 
   @Nested
@@ -129,7 +110,7 @@ class LearnStatsTest {
               );
 
       // when
-      projection.recalibrate(150L, 120L, 20, completedDates);
+      projection.recalibrate(150L, 120L, 20, completedDates, today);
 
       // then
       assertThat(projection.getTotalSolvedQuestionCount()).isEqualTo(150L);
@@ -147,7 +128,7 @@ class LearnStatsTest {
 
       // when
 
-      projection.recalibrate(10L, 8L, 5, List.of());
+      projection.recalibrate(10L, 8L, 5, List.of(), today);
 
       // then
       assertThat(projection.getTotalSolvedQuestionCount()).isEqualTo(10L);

--- a/src/test/java/kr/it/pullit/modules/projection/learnstats/service/LearnStatsFacadeImplTest.java
+++ b/src/test/java/kr/it/pullit/modules/projection/learnstats/service/LearnStatsFacadeImplTest.java
@@ -38,7 +38,7 @@ class LearnStatsFacadeImplTest {
     void givenExistingLearnStatsReturnsCombinedStats() {
       // given
       LearnStats existingStats = LearnStats.newOf(memberId);
-      existingStats.increaseCorrectQuestionCount(10); // 임의의 통계 데이터 추가
+      existingStats.updateTotalCorrectQuestionCount(10); // 임의의 통계 데이터 추가
 
       long totalQuestionSetCount = 20L;
 

--- a/src/test/java/kr/it/pullit/modules/projection/learnstats/service/LearnStatsServiceTest.java
+++ b/src/test/java/kr/it/pullit/modules/projection/learnstats/service/LearnStatsServiceTest.java
@@ -4,10 +4,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-
 import java.util.Optional;
 import kr.it.pullit.modules.projection.learnstats.domain.LearnStats;
 import kr.it.pullit.modules.projection.learnstats.repository.LearnStatsRepository;
+import kr.it.pullit.modules.questionset.api.MarkingResultPublicApi;
 import kr.it.pullit.modules.questionset.api.QuestionSetPublicApi;
 import kr.it.pullit.support.annotation.SpringUnitTest;
 import kr.it.pullit.support.config.MutableClockConfig;
@@ -28,6 +28,8 @@ class LearnStatsServiceTest {
   @MockitoBean private LearnStatsRepository learnStatsRepository;
 
   @MockitoBean private QuestionSetPublicApi questionSetPublicApi;
+
+  @MockitoBean private MarkingResultPublicApi markingResultPublicApi;
 
   @Nested
   @DisplayName("주간 초기화 적용 시")
@@ -108,12 +110,11 @@ class LearnStatsServiceTest {
     void givenExistingProjectionThenUpdatesAndSaves() {
       // given
       Long memberId = 1L;
-      long correctCount = 5L;
       LearnStats existingProjection = LearnStats.newOf(memberId);
       given(learnStatsRepository.findById(memberId)).willReturn(Optional.of(existingProjection));
 
       // when
-      sut.increaseCorrectQuestionCount(memberId, correctCount);
+      sut.recalculateCorrectQuestionCount(memberId);
 
       // then
       verify(learnStatsRepository, times(1)).save(existingProjection);
@@ -124,11 +125,10 @@ class LearnStatsServiceTest {
     void givenNoProjectionThenCreatesUpdatesAndSaves() {
       // given
       Long memberId = 1L;
-      long correctCount = 5L;
       given(learnStatsRepository.findById(memberId)).willReturn(Optional.empty());
 
       // when
-      sut.increaseCorrectQuestionCount(memberId, correctCount);
+      sut.recalculateCorrectQuestionCount(memberId);
 
       // then
       verify(learnStatsRepository, times(1)).save(any(LearnStats.class));

--- a/src/test/java/kr/it/pullit/modules/projection/learnstats/service/LearnStatsServiceTest.java
+++ b/src/test/java/kr/it/pullit/modules/projection/learnstats/service/LearnStatsServiceTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+
 import java.util.Optional;
 import kr.it.pullit.modules.projection.learnstats.domain.LearnStats;
 import kr.it.pullit.modules.projection.learnstats.repository.LearnStatsRepository;

--- a/src/test/java/kr/it/pullit/modules/projection/learnstats/service/LearnStatsServiceTest.java
+++ b/src/test/java/kr/it/pullit/modules/projection/learnstats/service/LearnStatsServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+
 import java.util.Optional;
 import kr.it.pullit.modules.projection.learnstats.domain.LearnStats;
 import kr.it.pullit.modules.projection.learnstats.repository.LearnStatsRepository;

--- a/src/test/java/kr/it/pullit/modules/projection/learnstats/service/LearnStatsServiceTest.java
+++ b/src/test/java/kr/it/pullit/modules/projection/learnstats/service/LearnStatsServiceTest.java
@@ -1,10 +1,10 @@
 package kr.it.pullit.modules.projection.learnstats.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-
 import java.util.Optional;
 import kr.it.pullit.modules.projection.learnstats.domain.LearnStats;
 import kr.it.pullit.modules.projection.learnstats.repository.LearnStatsRepository;
@@ -111,6 +111,9 @@ class LearnStatsServiceTest {
     void givenExistingProjectionThenUpdatesAndSaves() {
       // given
       Long memberId = 1L;
+      long expectedCorrectCount = 5L;
+      given(markingResultPublicApi.countCorrectAnswersByMemberId(memberId))
+          .willReturn(expectedCorrectCount);
       LearnStats existingProjection = LearnStats.newOf(memberId);
       given(learnStatsRepository.findById(memberId)).willReturn(Optional.of(existingProjection));
 
@@ -118,7 +121,9 @@ class LearnStatsServiceTest {
       sut.recalculateCorrectQuestionCount(memberId);
 
       // then
+      verify(markingResultPublicApi, times(1)).countCorrectAnswersByMemberId(memberId);
       verify(learnStatsRepository, times(1)).save(existingProjection);
+      assertThat(existingProjection.getTotalCorrectQuestionCount()).isEqualTo(expectedCorrectCount);
     }
 
     @Test
@@ -126,12 +131,16 @@ class LearnStatsServiceTest {
     void givenNoProjectionThenCreatesUpdatesAndSaves() {
       // given
       Long memberId = 1L;
+      long expectedCorrectCount = 5L;
+      given(markingResultPublicApi.countCorrectAnswersByMemberId(memberId))
+          .willReturn(expectedCorrectCount);
       given(learnStatsRepository.findById(memberId)).willReturn(Optional.empty());
 
       // when
       sut.recalculateCorrectQuestionCount(memberId);
 
       // then
+      verify(markingResultPublicApi, times(1)).countCorrectAnswersByMemberId(memberId);
       verify(learnStatsRepository, times(1)).save(any(LearnStats.class));
     }
   }

--- a/src/test/java/kr/it/pullit/modules/projection/learnstats/service/LearnStatsValidationServiceTest.java
+++ b/src/test/java/kr/it/pullit/modules/projection/learnstats/service/LearnStatsValidationServiceTest.java
@@ -32,7 +32,12 @@ class LearnStatsValidationServiceTest {
     LearnStats stats = LearnStats.newOf(member.getId());
     // 이틀 전이 마지막 학습일이라고 가정 (어제 학습 누락)
 
-    stats.recalibrate(10L, 8L, 5, List.of(LocalDate.now(clock).minusDays(2).atStartOfDay()));
+    stats.recalibrate(
+        10L,
+        8L,
+        5,
+        List.of(LocalDate.now(clock).minusDays(2).atStartOfDay()),
+        LocalDate.now(clock));
     learnStatsRepository.save(stats);
 
     // when

--- a/src/test/java/kr/it/pullit/modules/questionset/service/MarkingCompletedEventHandlerTest.java
+++ b/src/test/java/kr/it/pullit/modules/questionset/service/MarkingCompletedEventHandlerTest.java
@@ -41,21 +41,6 @@ class MarkingCompletedEventHandlerTest {
   }
 
   @Test
-  @DisplayName("채점 완료 시 정답 개수가 0이면 정답 수 이벤트를 발행하지 않는다")
-  void shouldNotPublishCorrectAnswerCountEventWhenNoCorrectAnswers() {
-    // given
-    var memberId = 1L;
-    var results = List.of(new MarkingResultDto(1L, false), new MarkingResultDto(2L, false));
-    var event = new MarkingCompletedEvent(memberId, results, false);
-
-    // when
-    sut.handleMarkingCompletedEvent(event);
-
-    // then
-    verify(learnStatsEventPublicApi, never()).publishRecalculateCorrectAnswerCount(memberId);
-  }
-
-  @Test
   @DisplayName("채점 완료 시 solvedQuestionCount가 0보다 크면 이벤트를 발행한다")
   void shouldPublishEventWhenResultExists() {
     // given

--- a/src/test/java/kr/it/pullit/modules/questionset/service/MarkingCompletedEventHandlerTest.java
+++ b/src/test/java/kr/it/pullit/modules/questionset/service/MarkingCompletedEventHandlerTest.java
@@ -37,7 +37,7 @@ class MarkingCompletedEventHandlerTest {
     sut.handleMarkingCompletedEvent(event);
 
     // then
-    verify(learnStatsEventPublicApi).publishCorrectAnswerCount(memberId, expectedCorrectCount);
+    verify(learnStatsEventPublicApi).publishRecalculateCorrectAnswerCount(memberId);
   }
 
   @Test
@@ -52,7 +52,7 @@ class MarkingCompletedEventHandlerTest {
     sut.handleMarkingCompletedEvent(event);
 
     // then
-    verify(learnStatsEventPublicApi, never()).publishCorrectAnswerCount(memberId, 0L);
+    verify(learnStatsEventPublicApi, never()).publishRecalculateCorrectAnswerCount(memberId);
   }
 
   @Test


### PR DESCRIPTION
<!-- PR 제목을 `이슈번호: 작업내용(명확히)`로 작성해주세요. -->

## PR 설명

learn-stat-계산방식 변경 및 마이그레이션 api에도 잔디 값 바꾸도록 변경

<!--Release Notes:

- N/A _or_ Added/Fixed/Improved ...-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Learning statistics recalibrated using current-date-aware logic for more accurate streak calculations.
  * Correct-answer handling moved to a recalculation flow so totals reflect authoritative counts.
  * Event publishing now triggers recalculation instead of relying on incremental deltas.
* **Tests**
  * Tests updated to align with new recalculation and streak semantics.
* **Chores**
  * QA compose environments updated with web application type and management port settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->